### PR TITLE
`apply_method` to handle keyword argument better

### DIFF
--- a/blocks/__init__.py
+++ b/blocks/__init__.py
@@ -1,1 +1,3 @@
 """The blocks library for parameterized Theano ops"""
+
+from bricks import Brick

--- a/blocks/tests/test_brick.py
+++ b/blocks/tests/test_brick.py
@@ -1,0 +1,50 @@
+from blocks.bricks import Brick
+from theano import tensor
+
+class Identity(Brick):
+
+    @Brick.apply_method
+    def apply(self, a, b=1, **kwargs):
+        if isinstance(a, list):
+            a = a[0]
+        return [a, b] + kwargs.values()
+
+def test_apply_method():
+    brick = Identity()
+    x = tensor.vector('x')
+    y = tensor.vector('y')
+    z = tensor.vector('z')
+
+    def check_output_variable(o):
+        assert o.tag.owner == brick
+        assert o.owner.inputs[0].tag.owner == brick
+
+    # Case 1: both positional arguments are provided.
+    u, v = brick.apply(x, y)
+    for o in [u, v]:
+        check_output_variable(o)
+
+    # Case 2: `b` is given as a keyword argument.
+    u, v = brick.apply(x, b=y)
+    for o in [u, v]:
+        check_output_variable(o)
+
+    # Case 3: two positional and one keyword argument.
+    u, v, w = brick.apply(x, y, c=z)
+    for o in [u, v, w]:
+        check_output_variable(o)
+
+    # Case 4: one positional argument.
+    u, v = brick.apply(x)
+    check_output_variable(u)
+    assert v == 1
+
+    # Case 5: variable was wrapped in a list. We can not handle that.
+    try:
+        u, v = brick.apply([x])
+        check_output_variable(u)
+    except AttributeError:
+        pass
+    else:
+        assert False
+


### PR DESCRIPTION
Variables given as keyword arguments were not noticed by the
`apply_method` decorator before. This commit fixes that. In addition
the case when an output is not a Theano variable is checked.
