### PR TITLE
Ignore eclipse files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Eclipse 
+.project
+.pydevproject
+.settings/


### PR DESCRIPTION
Additions to .gitignore to ignore eclipse pydev project and configuration folders.
