### PR TITLE
WIP: Database backend for log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ language: python
 python:
   - "2.7"
   - "3.4"
+services:
+  - mongodb
 env:
   - TESTS=float32
   - TESTS=float64
@@ -36,6 +38,7 @@ install:
   # Install all Python dependencies
   - conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl bokeh nose numpy pip coverage six scipy toolz
   - pip install -q nose2[coverage-plugin] coveralls
+  - pip install git+git://github.com/mongodb/mongo-python-driver.git@3.0b0#egg=pymongo
 script:
   - pip install . -r requirements.txt # Tests setup.py
   - # Must export environment variable so that the subprocess is aware of it

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -459,7 +459,7 @@ class ProgressBar(TrainingExtension):
 
         """
         iter_per_epoch = self.get_iter_per_epoch()
-        epochs_done = self.main_loop.log._status.epochs_done
+        epochs_done = self.main_loop.log.status['epochs_done']
 
         if iter_per_epoch is None:
             widgets = ["Epoch {}, step ".format(epochs_done),

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -549,8 +549,6 @@ class Timing(TrainingExtension):
 
     def before_training(self):
         self.started_at = self.clock_function()
-        self.log.status.exclude.extend(['epoch_before_interrupted',
-                                        'total_before_interrupted'])
         self.log.status['epoch_before_interrupted'] = 0
         self.log.status['total_before_interrupted'] = 0
 
@@ -585,7 +583,8 @@ class Timing(TrainingExtension):
         self.log.status['total_before_interrupted'] = (
             self.log.current_entry['final_total_took'])
         if self.log.status['epoch_started']:
-            epoch_ends = self.log.status['epoch_ends']
+            epoch_ends = [key for key, value in self.log.items()
+                          if 'epoch_ended' in value]
             self.log.status['epoch_before_interrupted'] = (
                 self.clock_function() - 0
                 if not epoch_ends else self.log[epoch_ends[-1]]['total_took'])

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -377,9 +377,8 @@ class Printing(SimpleExtension):
         super(Printing, self).__init__(**kwargs)
 
     def _print_attributes(self, attribute_tuples):
-        for attr, value in sorted(attribute_tuples, key=first):
-            if not attr.startswith("_"):
-                print("\t", "{}:".format(attr), value)
+        for attr, value in sorted(attribute_tuples.items(), key=first):
+            print("\t", "{}:".format(attr), value)
 
     def do(self, which_callback, *args):
         log = self.main_loop.log

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -153,9 +153,9 @@ class Predicate(object):
 
     def __call__(self, log):
         if self.condition.endswith('epochs'):
-            entry = log.status.epochs_done
+            entry = log.status['epochs_done']
         else:
-            entry = log.status.iterations_done
+            entry = log.status['iterations_done']
         if self.condition.startswith('every'):
             return entry % self.num == 0
         else:
@@ -163,7 +163,7 @@ class Predicate(object):
 
 
 def has_done_epochs(log):
-    return log.status.epochs_done == 0
+    return log.status['epochs_done'] == 0
 
 
 def always_true(log):
@@ -363,7 +363,7 @@ class FinishAfter(SimpleExtension):
         super(FinishAfter, self).__init__(**kwargs)
 
     def do(self, which_callback, *args):
-        self.main_loop.log.current_row.training_finish_requested = True
+        self.main_loop.log.current_row['training_finish_requested'] = True
 
 
 class Printing(SimpleExtension):
@@ -387,7 +387,7 @@ class Printing(SimpleExtension):
 
         print()
         print("".join(79 * "-"))
-        if which_callback == "before_epoch" and log.status.epochs_done == 0:
+        if which_callback == "before_epoch" and log.status['epochs_done'] == 0:
             print("BEFORE FIRST EPOCH")
         elif which_callback == "on_resumption":
             print("TRAINING HAS BEEN RESUMED")
@@ -403,7 +403,7 @@ class Printing(SimpleExtension):
             print("Training status:")
             self._print_attributes(log.status)
             print("Log records from the iteration {}:".format(
-                log.status.iterations_done))
+                log.status['iterations_done']))
             self._print_attributes(log.current_row)
         print()
 
@@ -550,44 +550,46 @@ class Timing(TrainingExtension):
 
     def before_training(self):
         self.started_at = self.clock_function()
-        self.log.status._epoch_before_interrupted = 0
-        self.log.status._total_before_interrupted = 0
+        self.log.status.exclude.extend(['epoch_before_interrupted',
+                                        'total_before_interrupted'])
+        self.log.status['epoch_before_interrupted'] = 0
+        self.log.status['total_before_interrupted'] = 0
 
     def before_epoch(self):
         self.epoch_started_at = self.clock_function()
-        if self.log.status.epochs_done == 0:
-            self.log.current_row.initialization_took = (
+        if self.log.status['epochs_done'] == 0:
+            self.log.current_row['initialization_took'] = (
                 self.epoch_started_at - self.started_at)
 
     def before_batch(self, batch):
         self.batch_started_at = self.clock_function()
 
     def after_batch(self, batch):
-        self.log.current_row.iteration_took = (
+        self.log.current_row['iteration_took'] = (
             self.clock_function() - self.batch_started_at)
-        self.log.current_row.total_took = (
-            self.log.status._total_before_interrupted +
+        self.log.current_row['total_took'] = (
+            self.log.status['total_before_interrupted'] +
             self.clock_function() - self.started_at)
 
     def after_epoch(self):
-        self.log.current_row.epoch_took = (
-            self.log.status._epoch_before_interrupted +
+        self.log.current_row['epoch_took'] = (
+            self.log.status['epoch_before_interrupted'] +
             self.clock_function() - self.epoch_started_at)
-        self.log.status._epoch_before_interrupted = 0
+        self.log.status['epoch_before_interrupted'] = 0
 
     def after_training(self):
-        self.log.current_row.final_total_took = (
-            self.log.status._total_before_interrupted +
+        self.log.current_row['final_total_took'] = (
+            self.log.status['total_before_interrupted'] +
             self.clock_function() - self.started_at)
 
         # Save intermediate results to the log.status
-        self.log.status._total_before_interrupted = (
-            self.log.current_row.final_total_took)
-        if self.log.status._epoch_started:
-            epoch_ends = self.log.status._epoch_ends
-            self.log.status._epoch_before_interrupted = (
-                self.clock_function() -
-                0 if not epoch_ends else self.log[epoch_ends[-1]].total_took)
+        self.log.status['total_before_interrupted'] = (
+            self.log.current_row['final_total_took'])
+        if self.log.status['epoch_started']:
+            epoch_ends = self.log.status['epoch_ends']
+            self.log.status['epoch_before_interrupted'] = (
+                self.clock_function() - 0
+                if not epoch_ends else self.log[epoch_ends[-1]]['total_took'])
 
     def on_resumption(self):
         self.started_at = self.clock_function()

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -363,7 +363,7 @@ class FinishAfter(SimpleExtension):
         super(FinishAfter, self).__init__(**kwargs)
 
     def do(self, which_callback, *args):
-        self.main_loop.log.current_row['training_finish_requested'] = True
+        self.main_loop.log.current_entry['training_finish_requested'] = True
 
 
 class Printing(SimpleExtension):
@@ -404,7 +404,7 @@ class Printing(SimpleExtension):
             self._print_attributes(log.status)
             print("Log records from the iteration {}:".format(
                 log.status['iterations_done']))
-            self._print_attributes(log.current_row)
+            self._print_attributes(log.current_entry)
         print()
 
 
@@ -558,33 +558,33 @@ class Timing(TrainingExtension):
     def before_epoch(self):
         self.epoch_started_at = self.clock_function()
         if self.log.status['epochs_done'] == 0:
-            self.log.current_row['initialization_took'] = (
+            self.log.current_entry['initialization_took'] = (
                 self.epoch_started_at - self.started_at)
 
     def before_batch(self, batch):
         self.batch_started_at = self.clock_function()
 
     def after_batch(self, batch):
-        self.log.current_row['iteration_took'] = (
+        self.log.current_entry['iteration_took'] = (
             self.clock_function() - self.batch_started_at)
-        self.log.current_row['total_took'] = (
+        self.log.current_entry['total_took'] = (
             self.log.status['total_before_interrupted'] +
             self.clock_function() - self.started_at)
 
     def after_epoch(self):
-        self.log.current_row['epoch_took'] = (
+        self.log.current_entry['epoch_took'] = (
             self.log.status['epoch_before_interrupted'] +
             self.clock_function() - self.epoch_started_at)
         self.log.status['epoch_before_interrupted'] = 0
 
     def after_training(self):
-        self.log.current_row['final_total_took'] = (
+        self.log.current_entry['final_total_took'] = (
             self.log.status['total_before_interrupted'] +
             self.clock_function() - self.started_at)
 
         # Save intermediate results to the log.status
         self.log.status['total_before_interrupted'] = (
-            self.log.current_row['final_total_took'])
+            self.log.current_entry['final_total_took'])
         if self.log.status['epoch_started']:
             epoch_ends = self.log.status['epoch_ends']
             self.log.status['epoch_before_interrupted'] = (

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -132,7 +132,8 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
                 self._buffer.accumulation_updates)
             self._buffer.initialize_aggregators()
         else:
-            if self.main_loop.status['iterations_done'] == self._last_time_called:
+            if (self.main_loop.status['iterations_done'] ==
+                    self._last_time_called):
                 raise Exception("TrainingDataMonitoring.do should be invoked"
                                 " no more than once per iteration")
             self._last_time_called = self.main_loop.status['iterations_done']

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -37,7 +37,7 @@ class MonitoringExtension(TrainingExtension):
         for name, value in record_tuples:
             if not name:
                 raise ValueError("monitor variable without name")
-            setattr(log.current_row, self._record_name(name), value)
+            log.current_entry[self._record_name(name)] = value
 
 
 class DataStreamMonitoring(SimpleExtension, MonitoringExtension):
@@ -132,10 +132,10 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
                 self._buffer.accumulation_updates)
             self._buffer.initialize_aggregators()
         else:
-            if self.main_loop.status.iterations_done == self._last_time_called:
+            if self.main_loop.status['iterations_done'] == self._last_time_called:
                 raise Exception("TrainingDataMonitoring.do should be invoked"
                                 " no more than once per iteration")
-            self._last_time_called = self.main_loop.status.iterations_done
+            self._last_time_called = self.main_loop.status['iterations_done']
             self.add_records(self.main_loop.log,
                              self._buffer.get_aggregated_values().items())
             self._buffer.initialize_aggregators()

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -104,7 +104,7 @@ class Plot(SimpleExtension):
         log = self.main_loop.log
         iteration = log.status['iterations_done']
         i = 0
-        for key, value in log.current_entry:
+        for key, value in log.current_entry.items():
             if key in self.p_indices:
                 if key not in self.plots:
                     fig = self.p[self.p_indices[key]]

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -102,7 +102,7 @@ class Plot(SimpleExtension):
 
     def do(self, which_callback, *args):
         log = self.main_loop.log
-        iteration = log.status.iterations_done
+        iteration = log.status['iterations_done']
         i = 0
         for key, value in log.current_row:
             if key in self.p_indices:

--- a/blocks/extensions/plot.py
+++ b/blocks/extensions/plot.py
@@ -104,7 +104,7 @@ class Plot(SimpleExtension):
         log = self.main_loop.log
         iteration = log.status['iterations_done']
         i = 0
-        for key, value in log.current_row:
+        for key, value in log.current_entry:
             if key in self.p_indices:
                 if key not in self.plots:
                     fig = self.p[self.p_indices[key]]

--- a/blocks/extensions/predicates.py
+++ b/blocks/extensions/predicates.py
@@ -11,4 +11,4 @@ class OnLogRecord(object):
         self.record_name = record_name
 
     def __call__(self, log):
-        return bool(log.current_row[self.record_name])
+        return bool(log.current_entry[self.record_name])

--- a/blocks/extensions/predicates.py
+++ b/blocks/extensions/predicates.py
@@ -11,4 +11,4 @@ class OnLogRecord(object):
         self.record_name = record_name
 
     def __call__(self, log):
-        return bool(log.current_entry[self.record_name])
+        return log.current_entry.get(self.record_name, False)

--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -71,9 +71,8 @@ class Checkpoint(SimpleExtension):
             path = self.path
             if len(from_user):
                 path, = from_user
-            already_saved_to = self.main_loop.log.current_entry[SAVED_TO]
-            if not already_saved_to:
-                already_saved_to = ()
+            already_saved_to = self.main_loop.log.current_entry.get(SAVED_TO,
+                                                                    ())
             self.main_loop.log.current_entry[SAVED_TO] = (
                 already_saved_to + (path,))
             secure_pickle_dump(self.main_loop, path)

--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -71,10 +71,10 @@ class Checkpoint(SimpleExtension):
             path = self.path
             if len(from_user):
                 path, = from_user
-            already_saved_to = self.main_loop.log.current_row[SAVED_TO]
+            already_saved_to = self.main_loop.log.current_entry[SAVED_TO]
             if not already_saved_to:
                 already_saved_to = ()
-            self.main_loop.log.current_row[SAVED_TO] = (
+            self.main_loop.log.current_entry[SAVED_TO] = (
                 already_saved_to + (path,))
             secure_pickle_dump(self.main_loop, path)
             for attribute in self.save_separately:
@@ -82,7 +82,7 @@ class Checkpoint(SimpleExtension):
                 path = root + "_" + attribute + ext
                 secure_pickle_dump(getattr(self.main_loop, attribute), path)
         except Exception:
-            self.main_loop.log.current_row[SAVED_TO] = None
+            self.main_loop.log.current_entry[SAVED_TO] = None
             raise
 
 
@@ -113,7 +113,7 @@ class LoadFromDump(TrainingExtension):
                     .format(self.manager.folder))
         try:
             self.manager.load_to(self.main_loop)
-            self.main_loop.log.current_row[LOADED_FROM] = self.manager.folder
+            self.main_loop.log.current_entry[LOADED_FROM] = self.manager.folder
         except Exception:
             reraise_as("Failed to load the state")
 
@@ -142,9 +142,9 @@ class Dump(SimpleExtension):
 
     def do(self, callback_name, *args, **kwargs):
         try:
-            self.main_loop.log.current_row[SAVED_TO] = (
+            self.main_loop.log.current_entry[SAVED_TO] = (
                 self.manager.folder)
             self.manager.dump(self.main_loop)
         except Exception:
-            self.main_loop.log.current_row[SAVED_TO] = None
+            self.main_loop.log.current_entry[SAVED_TO] = None
             raise

--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -72,9 +72,11 @@ class Checkpoint(SimpleExtension):
             if len(from_user):
                 path, = from_user
             already_saved_to = self.main_loop.log.current_entry.get(SAVED_TO,
-                                                                    ())
+                                                                    [])
+            if not isinstance(already_saved_to, list):
+                already_saved_to = [already_saved_to]
             self.main_loop.log.current_entry[SAVED_TO] = (
-                already_saved_to + (path,))
+                already_saved_to + [unicode(path)])
             secure_pickle_dump(self.main_loop, path)
             for attribute in self.save_separately:
                 root, ext = os.path.splitext(path)

--- a/blocks/extensions/training.py
+++ b/blocks/extensions/training.py
@@ -83,7 +83,7 @@ class TrackTheBest(SimpleExtension):
         current_value = self.main_loop.log.current_entry[self.record_name]
         if current_value is None:
             return
-        best_value = getattr(self.main_loop.status, self.best_name, None)
+        best_value = self.main_loop.status.get(self.best_name, None)
         if (best_value is None or
                 (current_value != best_value and
                  self.choose_best(current_value, best_value) ==

--- a/blocks/extensions/training.py
+++ b/blocks/extensions/training.py
@@ -80,7 +80,7 @@ class TrackTheBest(SimpleExtension):
         super(TrackTheBest, self).__init__(**kwargs)
 
     def do(self, which_callback, *args):
-        current_value = self.main_loop.log.current_row[self.record_name]
+        current_value = self.main_loop.log.current_entry[self.record_name]
         if current_value is None:
             return
         best_value = getattr(self.main_loop.status, self.best_name, None)
@@ -89,4 +89,4 @@ class TrackTheBest(SimpleExtension):
                  self.choose_best(current_value, best_value) ==
                  current_value)):
             self.main_loop.status[self.best_name] = current_value
-            self.main_loop.log.current_row[self.notification_name] = True
+            self.main_loop.log.current_entry[self.notification_name] = True

--- a/blocks/extensions/training.py
+++ b/blocks/extensions/training.py
@@ -36,7 +36,7 @@ class SharedVariableModifier(SimpleExtension):
         self.num_args = len(inspect.getargspec(function).args)
 
     def do(self, which_callback, *args):
-        iterations_done = self.main_loop.log.status.iterations_done
+        iterations_done = self.main_loop.log.status['iterations_done']
         if self.num_args == 1:
             new_value = self.function(iterations_done)
         else:

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -4,7 +4,11 @@ from numbers import Integral
 from operator import methodcaller
 
 from picklable_itertools import imap
-from pymongo import ASCENDING, MongoClient
+try:
+    from pymongo import ASCENDING, MongoClient
+    PYMONGO_AVAILABLE = True
+except ImportError:
+    PYMONGO_AVAILABLE = False
 
 
 class DefaultOrderedDict(OrderedDict):
@@ -141,6 +145,8 @@ class TrainingStatus(Mapping):
 class MongoTrainingLog(Mapping):
     """A training log stored in a MongoDB database."""
     def __init__(self):
+        if not PYMONGO_AVAILABLE:
+            raise ImportError('pymongo not installed')
         self.client = MongoClient()
         self.db = self.client.blocks_log
         self.entries = self.db.entries

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -3,11 +3,24 @@ from collections import Mapping, OrderedDict
 from numbers import Integral
 from operator import methodcaller
 
+from picklable_itertools import imap
 from pymongo import ASCENDING, MongoClient
-from six.moves import map
 
 
 class DefaultOrderedDict(OrderedDict):
+    r"""A ordered dictionary that supports default values.
+
+    Parameters
+    ----------
+    default_factor : callable, optional
+        A callable that returns the default value when a key is not found.
+        If not given, a KeyError will be raised instead.
+    \*args
+        Interpreted as ``dict``.
+    \*\*kwargs
+        Interpreted as ``dict``.
+
+    """
     def __init__(self, default_factory=None, *args, **kwargs):
         if default_factory is not None and not callable(default_factory):
             raise TypeError('first argument must be callable')
@@ -26,6 +39,33 @@ class DefaultOrderedDict(OrderedDict):
 
 
 class TrainingLog(Mapping):
+    """The log of training progress.
+
+    A training log stores the training timeline, statistics and other
+    auxiliary information. Information is represented as nested dictionary
+    of iteration, key values.
+
+    In addition to the set of records of the training progress, a training
+    log has a status object whose attributes describe the current state of
+    training e.g. whether training has started, whether termination has
+    been requested, etc.
+
+    Parameters
+    ----------
+    backend : {'default', 'mongo', 'sqlite'}
+        The log can be stored in a variety of backends. The `default`
+        backend stores the values in a nested dictionary (a
+        :class:`DefaultOrderedDict` to be precise). This is a simple and
+        fast option, but the log is difficult to access for analysis during
+        training, and can only be saved as a pickled Python object.
+
+        The `mongo` option uses a MongoDB database server to store the
+        logs. The `sqlite` value will use a local SQLite file to store the
+        results. Both of these backends will allow you to analyze results
+        easily even during training, and will allow you to save multiple
+        experiments to the same database.
+
+    """
     def __init__(self, backend='default', **kwargs):
         self.status = TrainingStatus()
         if backend == 'default':
@@ -56,6 +96,25 @@ class TrainingLog(Mapping):
 
 
 class TrainingStatus(Mapping):
+    """The status of the training process.
+
+    By default this contains two keys: `iterations_done` and `epochs_done`.
+
+    Parameters
+    ----------
+    exclude : list, optional
+        A list of status keys (strings) that should be excluded when
+        iterating over the status items. This can be useful when you want
+        to store a particular tidbit of information that should be
+        accessible to e.g. extensions, but don't want this to show up in
+        the log at every time step.
+
+    Attributes
+    ----------
+    exclude : list
+        See the parameters section.
+
+    """
     def __init__(self, exclude=None):
         self._status = {'iterations_done': 0, 'epochs_done': 0}
         self.exclude = [] if exclude is None else exclude
@@ -74,6 +133,7 @@ class TrainingStatus(Mapping):
 
 
 class MongoTrainingLog(Mapping):
+    """A training log stored in a MongoDB database."""
     def __init__(self):
         self.client = MongoClient()
         self.db = self.client.blocks_log
@@ -83,15 +143,31 @@ class MongoTrainingLog(Mapping):
         return MongoEntry(self, key)
 
     def __iter__(self):
-        return map(methodcaller('pop', '_id'),
-                   self.entries.find(projection=['_id'],
-                                     sort=[('_id', ASCENDING)]))
+        return imap(methodcaller('pop', '_id'),
+                    self.entries.find(projection=['_id'],
+                                      sort=[('_id', ASCENDING)]))
 
     def __len__(self):
         return self.entries.count()
 
 
 class MongoEntry(Mapping):
+    """A single entry in the MongoDB-based log.
+
+    Parameters
+    ----------
+    log : :class:`MongoTrainingLog`
+        The log this entry belongs to.
+    key : int
+        The key (``iterations_done``) that this entry belongs to.
+
+    Notes
+    -----
+    Entries are their own objects so that we can read lazily from the
+    MongoDB database, so if the user just wants to write new values, it
+    won't retrieve the old values.
+
+    """
     def __init__(self, log, key):
         self.log = log
         self.key = key

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -39,7 +39,7 @@ class DefaultOrderedDict(OrderedDict):
 
 
 class TrainingLog(Mapping):
-    """The log of training progress.
+    r"""The log of training progress.
 
     A training log stores the training timeline, statistics and other
     auxiliary information. Information is represented as nested dictionary
@@ -64,10 +64,16 @@ class TrainingLog(Mapping):
         results. Both of these backends will allow you to analyze results
         easily even during training, and will allow you to save multiple
         experiments to the same database.
+    status_exclude : list, optional
+        A list of status keys that should be excluded from iteration (and
+        hence, printing)
+    \*\*kwargs
+        Additional keyword arguments are passed to the log's backend e.g.
+        database configuration. See the relevant classes for details.
 
     """
-    def __init__(self, backend='default', **kwargs):
-        self.status = TrainingStatus()
+    def __init__(self, backend='default', status_exclude=None, **kwargs):
+        self.status = TrainingStatus(exclude=status_exclude)
         if backend == 'default':
             self._log = DefaultOrderedDict(dict)
         elif backend == 'mongo':

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -1,274 +1,117 @@
 """The event-based main loop of Blocks."""
-from abc import ABCMeta, abstractmethod
-from collections import defaultdict
+from collections import Mapping, OrderedDict
+from numbers import Integral
+from operator import methodcaller
 
-from six import add_metaclass
-try:
-    from pandas import DataFrame
-    PANDAS_AVAILABLE = True
-except ImportError:
-    PANDAS_AVAILABLE = False
+from pymongo import ASCENDING, MongoClient
+from six.moves import map
 
 
-@add_metaclass(ABCMeta)
-class AbstractTrainingStatus(object):
-    """The base class for objects that carry the training status.
+class DefaultOrderedDict(OrderedDict):
+    def __init__(self, default_factory=None, *args, **kwargs):
+        if default_factory is not None and not callable(default_factory):
+            raise TypeError('first argument must be callable')
+        self.default_factory = default_factory
+        super(DefaultOrderedDict, self).__init__(*args, **kwargs)
 
-    To support various backends (such as database tables) the
-    descendants of this class are expected to override the
-    `__getattr__`, `__setattr__`, `__hasattr__` methods.
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
 
-    Attributes
-    ----------
-    iterations_done : int
-        The number of iterations done.
-    epochs_done : int
-        The number of epochs done.
-    _epoch_ends : list
-        The numbers of the epochs last iterations.
+    def __reduce__(self):
+        args = (self.default_factory,)
+        return self.__class__, args, None, None, self.iteritems()
 
-    .. todo::
 
-        We need some notion of an attributes property. Examples of possible
-        properties include a docstring, a priority level to be used by a
-        printing extension to decide whether a certain attribute should be
-        printed or not.
-
-    """
-    def __init__(self):
-        self.iterations_done = 0
-        self.epochs_done = 0
-        self._epoch_ends = []
-
-    @abstractmethod
-    def __iter__(self):
-        """Return iterator through the status attributes.
-
-        The iterator should yield (attribute name, attribute value) pairs.
-
-        """
-        pass
+class TrainingLog(Mapping):
+    def __init__(self, backend='default', **kwargs):
+        self.status = TrainingStatus()
+        if backend == 'default':
+            self._log = DefaultOrderedDict(dict)
+        elif backend == 'mongo':
+            self._log = MongoTrainingLog(**kwargs)
+        else:
+            raise ValueError('unknown backend')
 
     def __getitem__(self, key):
-        return getattr(self, key)
+        if not isinstance(key, Integral) or key < 0:
+            raise TypeError('invalid timestamp: {}'.format(key))
+        return self._log[key]
+
+    def __iter__(self):
+        return iter(self._log)
+
+    def __len__(self):
+        return len(self._log)
+
+    @property
+    def current_entry(self):
+        return self[self.status['iterations_done']]
+
+    @property
+    def previous_entry(self):
+        return self[self.status['iterations_done'] - 1]
+
+
+class TrainingStatus(Mapping):
+    def __init__(self, exclude=None):
+        self._status = {'iterations_done': 0, 'epochs_done': 0}
+        self.exclude = [] if exclude is None else exclude
+
+    def __getitem__(self, key):
+        return self._status[key]
 
     def __setitem__(self, key, value):
-        return setattr(self, key, value)
+        self._status[key] = value
 
-    def __contains__(self, key):
-        return hasattr(self, key)
+    def __iter__(self):
+        return (key for key in self._status if key not in self.exclude)
+
+    def __len__(self):
+        return len(self._status)
 
 
-class TrainingLogRow(object):
-    """A convenience interface for a row of the training log.
+class MongoTrainingLog(Mapping):
+    def __init__(self):
+        self.client = MongoClient()
+        self.db = self.client.blocks_log
+        self.entries = self.db.entries
 
-    Parameters
-    ----------
-    log : instance of :class:`AbstractTrainingLog`.
-        The log to which the row belongs.
-    time : int
-        A time step of the row.
+    def __getitem__(self, key):
+        return MongoEntry(self, key)
 
-    """
-    def __init__(self, log, time):
+    def __iter__(self):
+        return map(methodcaller('pop', '_id'),
+                   self.entries.find(projection=['_id'],
+                                     sort=[('_id', ASCENDING)]))
+
+    def __len__(self):
+        return self.entries.count()
+
+
+class MongoEntry(Mapping):
+    def __init__(self, log, key):
         self.log = log
-        self.time = time
+        self.key = key
 
-    def __getattr__(self, key):
-        return self.log.fetch_record(self.time, key)
+    @property
+    def entry(self):
+        if not hasattr(self, '_entry'):
+            self._entry = self.log.entries.find_one({'_id': self.key},
+                                                    projection={'_id': False})
+        return self._entry
 
     def __getitem__(self, key):
-        return getattr(self, key)
+        return self.entry[key]
+
+    def __iter__(self):
+        return iter(self.entry)
+
+    def __len__(self):
+        return len(self.entry)
 
     def __setitem__(self, key, value):
-        setattr(self, key, value)
-
-    def __setattr__(self, key, value):
-        if key in ['log', 'time']:
-            return super(TrainingLogRow, self).__setattr__(key, value)
-        self.log.add_record(self.time, key, value)
-
-    def __iter__(self):
-        return self.log.get_row_iterator(self.time)
-
-
-@add_metaclass(ABCMeta)
-class AbstractTrainingLog(object):
-    """Base class for training logs.
-
-    A training log stores the training timeline, statistics and
-    other auxiliary information. Information is represented as a set of
-    time-key-value triples. A default value can be set for a key that
-    will be used when no other value is provided explicitly. The default
-    default value is ''None''.
-
-    In addition to the set of records displaying training dynamics, a
-    training log has a status object whose attributes form the state of
-
-    Another related concept is a row of the log, which is a set of record
-    sharing the same time component. The log interface has a few routines
-    to allow convenient access to the rows.
-
-    """
-    @abstractmethod
-    def get_status(self):
-        """Returns the training status.
-
-        Returns
-        -------
-            An instance of :class:`AbstractTrainingStatus`, whose
-            attributes contain the information regarding the status of
-            the training process.
-
-        """
-        pass
-
-    @property
-    def status(self):
-        """A convenient way to access the status."""
-        return self.get_status()
-
-    @abstractmethod
-    def set_default_value(self, key, value):
-        """Sets a default value for 'key'."""
-        pass
-
-    @abstractmethod
-    def get_default_value(self, key):
-        """Returns the default value set for the 'key'.
-
-        Returns
-        -------
-        The default value for the `key`, or ``None`` if not set.
-
-        """
-        pass
-
-    def add_record(self, time, key, value):
-        """Adds a record to the log.
-
-        If `value` equals to the default value for the `key`, nothing is
-        done.
-
-        """
-        self._check_time(time)
-        default_value = self.get_default_value(key)
-        if value != default_value:
-            self._add_record(time, key, value)
-
-    @abstractmethod
-    def _add_record(self, time, key, value):
-        """Adds a record to the log.
-
-        The implementation method to be overridden.
-
-        """
-        pass
-
-    def fetch_record(self, time, key):
-        """Fetches a record from the log.
-
-        If no such 'key' for the `time` is found or if the value for the
-        key is ``None``, the default value for the 'key' is returned.
-
-        """
-        self._check_time(time)
-        value = self._fetch_record(time, key)
-        if value is not None:
-            return value
-        return self.get_default_value(key)
-
-    @abstractmethod
-    def _fetch_record(self, time, key):
-        """Fetches a record from the log.
-
-        The implementation method to be overridden.
-
-        """
-        pass
-
-    def __getitem__(self, time):
-        self._check_time(time)
-        return TrainingLogRow(self, time)
-
-    @property
-    def current_row(self):
-        return self[self.status.iterations_done]
-
-    @property
-    def previous_row(self):
-        return self[self.status.iterations_done - 1]
-
-    @property
-    def last_epoch_row(self):
-        return self[self.status._epoch_ends[-1]]
-
-    @abstractmethod
-    def __iter__(self):
-        """Returns an iterator over time-key-value triples of the log."""
-        pass
-
-    @abstractmethod
-    def get_row_iterator(self, time):
-        """Returns an iterator over key-value pairs of a row of the log."""
-        pass
-
-    def _check_time(self, time):
-        if not isinstance(time, int) or time < 0:
-            raise ValueError("time must be a positive integer")
-
-    def to_dataframe(self):
-        """Convert a log into a :class:`.DataFrame`."""
-        if not PANDAS_AVAILABLE:
-            raise ImportError("The pandas library is not found. You can"
-                              " install it with pip.")
-        return self._to_dataframe()
-
-    def _to_dataframe(self):
-        raise NotImplementedError()
-
-
-class TrainingStatus(AbstractTrainingStatus):
-    """A simple training status."""
-    def __iter__(self):
-        for attr, value in self.__dict__.items():
-            if not attr.startswith("__"):
-                yield attr, value
-
-
-class TrainingLog(AbstractTrainingLog):
-    """A simple training log storing information in main memory."""
-    def __init__(self):
-        self._storage = defaultdict(dict)
-        self._default_values = {}
-        self._status = TrainingStatus()
-
-    def get_default_value(self, key):
-        return self._default_values.get(key)
-
-    def set_default_value(self, key, value):
-        self._default_values[key] = value
-
-    def _add_record(self, time, key, value):
-        self._storage[time][key] = value
-
-    def _fetch_record(self, time, key):
-        slice_ = self._storage.get(time)
-        if not slice_:
-            return None
-        return slice_.get(key)
-
-    def get_row_iterator(self, time):
-        for key, value in self._storage[time].items():
-            yield key, value
-
-    def __iter__(self):
-        for time, records in self._storage.items():
-            for key, value in records.items():
-                yield time, key, value
-
-    def get_status(self):
-        return self._status
-
-    def _to_dataframe(self):
-        return DataFrame.from_dict(self._storage, orient='index')
+        self.log.entries.update_one({'_id': self.key}, {'$set': {key: value}},
+                                    upsert=True)

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -2,52 +2,21 @@
 import binascii
 import datetime
 import os
-import sqlite3
-from abc import ABCMeta, abstractproperty
-from collections import Mapping, OrderedDict
+# import sqlite3
+from abc import ABCMeta, abstractmethod
+from collections import Mapping, MutableMapping, OrderedDict
 from numbers import Integral
 from operator import itemgetter
 
 import numpy
 import six
-from picklable_itertools import imap, groupby
+from picklable_itertools import imap
 try:
     from bson.objectid import ObjectId
     from pymongo import MongoClient
     PYMONGO_AVAILABLE = True
 except ImportError:
     PYMONGO_AVAILABLE = False
-
-
-class DefaultOrderedDict(OrderedDict):
-    r"""A ordered dictionary that supports default values.
-
-    Parameters
-    ----------
-    default_factor : callable, optional
-        A callable that returns the default value when a key is not found.
-        If not given, a KeyError will be raised instead.
-    \*args
-        Interpreted as ``dict``.
-    \*\*kwargs
-        Interpreted as ``dict``.
-
-    """
-    def __init__(self, default_factory=None, *args, **kwargs):
-        if default_factory is not None and not callable(default_factory):
-            raise TypeError('first argument must be callable')
-        self.default_factory = default_factory
-        super(DefaultOrderedDict, self).__init__(*args, **kwargs)
-
-    def __missing__(self, key):
-        if self.default_factory is None:
-            raise KeyError(key)
-        self[key] = value = self.default_factory()
-        return value
-
-    def __reduce__(self):
-        args = (self.default_factory,)
-        return self.__class__, args, None, None, six.iteritems(self)
 
 
 class TrainingLog(Mapping):
@@ -65,9 +34,9 @@ class TrainingLog(Mapping):
     Parameters
     ----------
     hash_ : str, optional
-        A hash that identifies this experiment. If given and a database
-        backend is used, it will try to reload the log. If not, a new hash
-        will be created for this log.
+        A 12-byte hexidecimal string that identifies this experiment. If
+        given and a database backend is used, it will try to reload the
+        log. If not, a new hash will be created for this log.
     backend : {'default', 'mongodb', 'sqlite'}, optional
         The log can be stored in a variety of backends. The `default`
         backend stores the values in a nested dictionary (a
@@ -95,14 +64,24 @@ class TrainingLog(Mapping):
         This dictionary contains information on the current status of the
         training e.g. how many iterations/epochs have been completed,
         whether training has finished, if errors occurred, etc.
+    hidden : dict
+        A dictionary with three keys: `entries`, `info` and `status`. The
+        values contain lists of entries that should be hidden by default
+        e.g. not printed, displayed or counted. You can append values to
+        these lists if you want to store some sort of metadata in e.g. the
+        `status` object, but don't want it to be printed by the
+        :class:`.Printing` extension at each step.
 
     Notes
     -----
-    Currently logs assume that entries are added in order.
+    Logs assume that entries are added in order. Don't try to insert log
+    entries in the middle of the current log; this behaviour is undefined.
+
+    MongoDB automatically casts tuples to lists. To avoid surprises, it is
+    a good idea to convert tuples to lists before storing them in MongoDB.
 
     """
     def __init__(self, hash_=None, backend='mongodb', **kwargs):
-        self.status = TrainingStatus()
         if hash_ is None:
             hash_ = binascii.hexlify(os.urandom(12)).decode()
         else:
@@ -115,26 +94,38 @@ class TrainingLog(Mapping):
                 is_valid_hash = False
             if not is_valid_hash:
                 raise ValueError('invalid hash')
-        self.info = {'hash': hash_}
+
         if backend == 'default':
-            self._log = DefaultOrderedDict(dict)
+            self.handler = InMemoryHandler(log=self, hash_=hash_)
         elif backend == 'mongodb':
-            self._log = MongoTrainingLog(log=self, **kwargs)
-        elif backend == 'sqlite':
-            self._log = SQLiteLog(**kwargs)
+            self.handler = MongoDBHandler(log=self, hash_=hash_, **kwargs)
+        # elif backend == 'sqlite':
+        #     self.handler = SQLiteLog(self, hash_, **kwargs)
         else:
             raise ValueError('unknown backend')
+
+        self.info.setdefault('created', datetime.datetime.utcnow())
+        self.status.setdefault('iterations_done', 0)
+        self.status.setdefault('epochs_done', 0)
 
     def __getitem__(self, key):
         if not isinstance(key, Integral) or key < 0:
             raise TypeError('invalid timestamp: {}'.format(key))
-        return self._log[key]
+        return self.handler.entries[key]
 
     def __iter__(self):
-        return iter(self._log)
+        return iter(self.handler.entries)
 
     def __len__(self):
-        return len(self._log)
+        return len(self.handler.entries)
+
+    @property
+    def status(self):
+        return self.handler.status
+
+    @property
+    def info(self):
+        return self.handler.info
 
     @property
     def current_entry(self):
@@ -145,79 +136,125 @@ class TrainingLog(Mapping):
         return self[self.status['iterations_done'] - 1]
 
 
-class TrainingStatus(Mapping):
-    """The status of the training process.
+class LogHandler(object):
+    """Backends that store the information about training progress.
 
-    By default this contains two keys: `iterations_done` and `epochs_done`.
-    This object behaves like a dictionary, except that the keys in
-    `exclude` are ignored in many cases.
-
-    Parameters
-    ----------
-    exclude : list, optional
-        A list of status keys (strings) that should be excluded when
-        iterating over the status items. This can be useful when you want
-        to store a particular tidbit of information that should be
-        accessible to e.g. extensions, but don't want this to show up in
-        the log at every time step.
+    Log handlers' attributes are expected to adhere to the
+    :class:`~collections.MutableMapping` protocol (`status` and `info`) or
+    to the :class:`~collections.Mapping` protocol (`entries`).
 
     Attributes
     ----------
-    exclude : list
-        See the parameters section.
+    log : :class:`TrainingLog`
+        The log that the handler belongs to.
+    hash_ : str
+        The 12-byte (24-character hexidecimal) string that identifies this
+        experiment.
+    entries : :class:`~collections.Mapping`
+        A mapping from iterations (int) to a dictionary of keys (str) and
+        arbitrary values. Should return an empty dictionary if no key-value
+        pairs were stored.
+    info : :class:`~collections.MutableMapping`
+        A mapping from string keys to values.
+    status : :class:`~collections.MutableMapping`
+        A mapping from string keys to values.
 
     """
-    def __init__(self, exclude=None):
-        self._status = {'iterations_done': 0, 'epochs_done': 0,
-                        'epoch_ends': []}
-        self.exclude = [] if exclude is None else exclude
-
-    def __getitem__(self, key):
-        return self._status[key]
-
-    def __setitem__(self, key, value):
-        self._status[key] = value
-
-    def __iter__(self):
-        return (key for key in self._status if key not in self.exclude)
-
-    def __len__(self):
-        return len(iter(self))
-
-
-class TrainingLogBackend(Mapping):
-    def __init__(self, log):
+    def __init__(self, log, hash_):
         self.log = log
+        self.hash_ = hash_
 
 
-class MongoTrainingLog(TrainingLogBackend):
-    """A training log stored in a MongoDB database."""
+class InMemoryHandler(LogHandler):
+    """Log handler that stores all data as in-memory Python objects."""
+    def __init__(self, *args, **kwargs):
+        super(InMemoryHandler, self).__init__(*args, **kwargs)
+        self.entries = DefaultOrderedDict(dict)
+        self.status = {}
+        self.info = {}
+
+
+class DefaultOrderedDict(OrderedDict):
+    r"""A ordered dictionary that supports default values.
+
+    Parameters
+    ----------
+    default_factory : callable, optional
+        A callable that returns the default value when a key is not found.
+        If not given, a KeyError will be raised instead.
+    \*args
+        Interpreted as ``dict``.
+    \*\*kwargs
+        Interpreted as ``dict``.
+
+    """
+    def __init__(self, default_factory=None, *args, **kwargs):
+        if default_factory is not None and not callable(default_factory):
+            raise TypeError('first argument must be callable')
+        self.default_factory = default_factory
+        super(DefaultOrderedDict, self).__init__(*args, **kwargs)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+
+    def __reduce__(self):
+        args = (self.default_factory,)
+        return self.__class__, args, None, None, six.iteritems(self)
+
+
+class MongoDBHandler(LogHandler):
+    """Log handler that stores data in a MongoDB database.
+
+    Parameters
+    ----------
+    database : str, optional
+        The database to connect to, `blocks` by default.
+    host : str, optional
+        The host on which the MongoDB server is running. By default it
+        assumes the database is running locally at `localhost`.
+    port : int, optional
+        The port at which MongoDB is listening. The default is 27017.
+
+    Attributes
+    ----------
+    objectid : bson.objectid.ObjectId
+        The 12-byte experiment hash as a BSON object, which MongoDB uses to
+        identify unique experiments.
+
+    """
     def __init__(self, database='blocks', host='localhost', port=27017,
                  *args, **kwargs):
         if not PYMONGO_AVAILABLE:
             raise ImportError('pymongo not installed')
-        super(MongoTrainingLog, self).__init__(*args, **kwargs)
+        super(MongoDBHandler, self).__init__(*args, **kwargs)
 
         self.host = host
         self.port = port
         self.database = database
-        self.mongo_id = ObjectId(self.log.info['hash'])
         self._connect()
 
     def _connect(self):
+        self.objectid = ObjectId(self.hash_)
         self.client = MongoClient(host=self.host, port=self.port)
         self.db = self.client[self.database]
         self.experiments = self.db['experiments']
-        self.entries = self.db['entries']
         # Create the experiment if it does not exist already
         self.experiments.update_one(
-            {'_id': self.mongo_id},
-            {'$setOnInsert': {'created': datetime.datetime.utcnow()}},
-            upsert=True)
+            {'_id': self.objectid}, {'$setOnInsert': {
+                '_id': self.objectid, 'info': {}, 'status': {}
+            }}, upsert=True)
+
+        self.entries = MongoDBEntries(self)
+        self.info = MongoDBDict(self, 'info')
+        self.status = MongoDBDict(self, 'status')
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        for attr in ['client', 'db', 'entries', 'experiments']:
+        for attr in ['client', 'db', 'info', 'status', 'entries',
+                     'experiments', 'objectid']:
             del state[attr]
         return state
 
@@ -225,124 +262,157 @@ class MongoTrainingLog(TrainingLogBackend):
         self.__dict__.update(state)
         self._connect()
 
+
+@six.add_metaclass(ABCMeta)
+class LazyMapping(MutableMapping):
+    """A helper class for log entries stored in a database.
+
+    Database entries should only be read when explicitly accessed, that is,
+    we don't want ``log[0]['foo'] = 'bar'`` to result in ``log[0]['foo']``
+    being read from the database. This class defines some helper functions
+    for a log entry that behaves this way.
+
+    """
+    def __repr__(self):
+        return repr(self._get())
+
+    @abstractmethod
+    def _get(self):
+        """Returns the mapping."""
+        pass
+
+    def __getitem__(self, key):
+        return self._get()[key]
+
+    def __iter__(self):
+        return iter(self._get())
+
+    def __len__(self):
+        return len(self._get())
+
+
+class MongoDBDict(LazyMapping):
+    """Stores a dictionary of keys-values with a MongoDB experiment."""
+    def __init__(self, handler, name):
+        self.handler = handler
+        self.name = name
+        self.experiments = self.handler.db['experiments']
+
+        self._filter = {'_id': self.handler.objectid}
+
+    def _get(self):
+        """Retrieves the dictionary from the MongoDB database."""
+        return self.experiments.find_one(self._filter,
+                                         projection=[self.name])[self.name]
+
+    def __setitem__(self, key, value):
+        self.experiments.update_one(
+            self._filter, {'$set': {'{}.{}'.format(self.name, key): value}}
+        )
+
+    def __delitem__(self, key):
+        self.experiments.delete_one(
+            self._filter, {'$unset': {'{}.{}'.format(self.name, key): ''}}
+        )
+
+
+class MongoDBEntries(Mapping):
+    """Wrapper for log entries stored in MongoDB server.
+
+    Entries are stored as documents in the `entries` collection with the
+    structure::
+
+       {
+         'experiment': ObjectID(...),
+         'iteration': 3,
+         'cost': 0.8,
+         'saved_to': 'model.pkl'
+       }
+
+    """
+    def __init__(self, handler):
+        self.handler = handler
+        self.entries = handler.db['entries']
+
     def __getitem__(self, key):
         return MongoEntry(self, key)
 
     def __iter__(self):
         return imap(itemgetter('iteration'),
-                    self.entries.find({'experiment': self.mongo_id},
+                    self.entries.find({'experiment': self.handler.objectid},
                                       projection=['iteration']))
 
     def __len__(self):
-        return self.entries.count({'experiment': self.mongo_id})
+        return self.entries.count({'experiment': self.handler.objectid})
 
 
-@six.add_metaclass(ABCMeta)
-class DatabaseEntry(Mapping):
-    """A helper class for log entries stored in a database.
+class MongoEntry(LazyMapping):
+    """A single entry in the MongoDB-based log."""
+    def __init__(self, collection, iteration):
+        self.iteration = iteration
+        self.objectid = collection.handler.objectid
+        self.entries = collection.entries
 
-    Database entries should only be read when explicitly accessed, that is,
-    we don't want ``log[0]['foo'] = 'bar'`` to result in ``log[0]`` being
-    read from the database. This class defines some helper functions for a
-    log entry that behaves this way.
-
-    """
-    def __init__(self, log, key):
-        self.log = log
-        self.key = key
-
-    def __repr__(self):
-        return repr(self.entry)
-
-    @abstractproperty
-    def entry(self):
-        """Should return the entry as a dictionary when requested."""
-        pass
-
-    def __getitem__(self, key):
-        return self.entry[key]
-
-    def __iter__(self):
-        return iter(self.entry)
-
-    def __len__(self):
-        return len(self.entry)
-
-
-class MongoEntry(DatabaseEntry):
-    """A single entry in the MongoDB-based log.
-
-    Parameters
-    ----------
-    log : :class:`MongoTrainingLog`
-        The log this entry belongs to.
-    key : int
-        The key (``iterations_done``) that this entry belongs to.
-
-    Notes
-    -----
-    Entries are their own objects so that we can read lazily from the
-    MongoDB database, so if the user just wants to write new values, it
-    won't retrieve the old values.
-
-    """
-    @property
-    def entry(self):
-        if not hasattr(self, '_entry'):
-            self._entry = self.log.entries.find_one(
-                {'experiment': self.log.mongo_id, 'iteration': self.key},
-                projection={'_id': False, 'experiment': False,
-                            'iteration': False})
-            if self._entry is None:
-                self._entry = {}
-        return self._entry
+    def _get(self):
+        entry = self.entries.find_one(
+            {'experiment': self.objectid, 'iteration': self.iteration},
+            projection={'_id': False, 'experiment': False,
+                        'iteration': False})
+        if entry is None:
+            entry = {}
+        return entry
 
     def __setitem__(self, key, value):
         if isinstance(value, numpy.ndarray):
             value = value.tolist()
-        self.log.entries.update_one({'experiment': self.log.mongo_id,
-                                     'iteration': self.key},
-                                    {'$set': {key: value}}, upsert=True)
+        self.entries.update_one({'experiment': self.objectid,
+                                 'iteration': self.iteration},
+                                {'$set': {key: value}}, upsert=True)
+
+    def __delitem__(self, key):
+        self.entries.update_one({'experiment': self.objectid,
+                                 'iteration': self.iteration},
+                                {'$unset': {key: ''}})
 
 
-def _grouper_to_dict(grouper):
-    """Converts an iterable of SQLite triplet log entries into a dict."""
-    _, entries = grouper
-    return dict([(key, value) for iteration, key, value in entries])
-
-
-class SQLiteLog(Mapping):
-    def __init__(self):
-        self.connection = sqlite3.connect('blocks.db')
-        self.cursor = self.connection.cursor()
-        self.cursor.execute('CREATE TABLE IF NOT EXISTS log '
-                            '(iteration INT, key TEXT, value NULL)')
-        self.connection.commit()
-
-    def __getitem__(self, key):
-        return SQLiteEntry(self, key)
-
-    def __iter__(self):
-        entries = self.cursor.execute('SELECT * FROM log')
-        return imap(_grouper_to_dict, groupby(entries, key=itemgetter(0)))
-
-    def __len__(self):
-        count, = self.cursor.execute('SELECT COUNT(DISTINCT iteration) '
-                                     'FROM LOG').fetchone()
-        return count
-
-
-class SQLiteEntry(DatabaseEntry):
-    @property
-    def entry(self):
-        if not hasattr(self, '_entry'):
-            entry = self.log.cursor.execute(
-                'SELECT * FROM log WHERE iteration = ?', (self.key,))
-            self._entry = dict([(key, value)
-                                for iteration, key, value in entry])
-        return self._entry
-
-    def __setitem__(self, key, value):
-        self.log.cursor.execute('INSERT INTO log VALUES (?, ?, ?)',
-                                (self.key, key, value))
-        self.log.connection.commit()
+# def _grouper_to_dict(grouper):
+#     """Converts an iterable of SQLite triplet log entries into a dict."""
+#     _, entries = grouper
+#     return dict([(key, value) for iteration, key, value in entries])
+#
+#
+# class SQLiteLog(Mapping):
+#     def __init__(self):
+#         self.connection = sqlite3.connect('blocks.db')
+#         self.cursor = self.connection.cursor()
+#         self.cursor.execute('CREATE TABLE IF NOT EXISTS log '
+#                             '(iteration INT, key TEXT, value NULL)')
+#         self.connection.commit()
+#
+#     def __getitem__(self, key):
+#         return SQLiteEntry(self, key)
+#
+#     def __iter__(self):
+#         entries = self.cursor.execute('SELECT * FROM log')
+#         return imap(_grouper_to_dict, groupby(entries, key=itemgetter(0)))
+#
+#     def __len__(self):
+#         count, = self.cursor.execute('SELECT COUNT(DISTINCT iteration) '
+#                                      'FROM LOG').fetchone()
+#         return count
+#
+#
+# class SQLiteEntry(DatabaseEntry):
+#     @property
+#     def entry(self):
+#         if not hasattr(self, '_entry'):
+#             entry = self.log.cursor.execute(
+#                 'SELECT * FROM log WHERE iteration = ?', (self.key,))
+#             self._entry = dict([(key, value)
+#                                 for iteration, key, value in entry])
+#         return self._entry
+#
+#     def __setitem__(self, key, value):
+#         self.log.cursor.execute('INSERT INTO log VALUES (?, ?, ?)',
+#                                 (self.key, key, value))
+#         self.log.connection.commit()

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -42,7 +42,7 @@ class DefaultOrderedDict(OrderedDict):
 
     def __reduce__(self):
         args = (self.default_factory,)
-        return self.__class__, args, None, None, self.iteritems()
+        return self.__class__, args, None, None, six.iteritems(self)
 
 
 class TrainingLog(Mapping):

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -149,8 +149,8 @@ class TrainingStatus(Mapping):
     """The status of the training process.
 
     By default this contains two keys: `iterations_done` and `epochs_done`.
-    This object behaves like a dictionary, except that the keys in `exclude`
-    are ignored in many cases.
+    This object behaves like a dictionary, except that the keys in
+    `exclude` are ignored in many cases.
 
     Parameters
     ----------

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -131,7 +131,8 @@ class TrainingStatus(Mapping):
 
     """
     def __init__(self, exclude=None):
-        self._status = {'iterations_done': 0, 'epochs_done': 0}
+        self._status = {'iterations_done': 0, 'epochs_done': 0,
+                        'epoch_ends': []}
         self.exclude = [] if exclude is None else exclude
 
     def __getitem__(self, key):

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -174,7 +174,8 @@ class MainLoop(object):
                 self.log.current_row['training_finished'] = True
             except Exception as e:
                 self._restore_signal_handlers()
-                self.log.current_row['got_exception'] = traceback.format_exc(e)
+                self.log.current_entry['got_exception'] = \
+                    traceback.format_exc(e)
                 logger.error("Error occured during training." + error_message)
                 try:
                     self._run_extensions('on_error')

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -171,7 +171,7 @@ class MainLoop(object):
                 while self._run_epoch():
                     pass
             except TrainingFinish:
-                self.log.current_row['training_finished'] = True
+                self.log.current_entry['training_finished'] = True
             except Exception as e:
                 self._restore_signal_handlers()
                 self.log.current_entry['got_exception'] = \
@@ -185,7 +185,7 @@ class MainLoop(object):
                                  error_in_error_handling_message)
                 reraise_as(e)
             finally:
-                if self.log.current_row['training_finished']:
+                if self.log.current_entry['training_finished']:
                     self._run_extensions('after_training')
                 self._restore_signal_handlers()
 
@@ -256,7 +256,7 @@ class MainLoop(object):
         # In case when keyboard interrupt is handled right at the end of
         # the iteration the corresponding log record can be found only in
         # the previous row.
-        if (self.log.current_row['training_finish_requested'] or
+        if (self.log.current_entry['training_finish_requested'] or
                 self.status['batch_interrupt_received']):
             raise TrainingFinish
         if (level == 'epoch' and
@@ -268,7 +268,7 @@ class MainLoop(object):
         logger.warning('Received epoch interrupt signal.' +
                        epoch_interrupt_message)
         signal.signal(signal.SIGINT, self._handle_batch_interrupt)
-        self.log.current_row['epoch_interrupt_received'] = True
+        self.log.current_entry['epoch_interrupt_received'] = True
         # Add a record to the status. Unlike the log record it will be
         # easy to access at later iterations.
         self.status['epoch_interrupt_received'] = True
@@ -278,7 +278,7 @@ class MainLoop(object):
         self._restore_signal_handlers()
         logger.warning('Received batch interrupt signal.' +
                        batch_interrupt_message)
-        self.log.current_row['batch_interrupt_received'] = True
+        self.log.current_entry['batch_interrupt_received'] = True
         # Add a record to the status. Unlike the log record it will be
         # easy to access at later iterations.
         self.status['batch_interrupt_received'] = True

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -84,14 +84,13 @@ class MainLoop(object):
     """
     def __init__(self, algorithm, data_stream,
                  model=None, log=None, extensions=None):
-        if not log:
-            log = TrainingLog(
-                status_exclude=['training_started', 'epoch_started',
-                                'epoch_interrupt_received',
-                                'batch_interrupt_received',
-                                'received_first_batch', 'epoch_ends']
-            )
-        if not extensions:
+        if log is None:
+            log = TrainingLog()
+        log.status.exclude.extend(['training_started', 'epoch_started',
+                                   'epoch_interrupt_received',
+                                   'batch_interrupt_received',
+                                   'received_first_batch', 'epoch_ends'])
+        if extensions is None:
             extensions = []
 
         self.data_stream = data_stream

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -185,7 +185,7 @@ class MainLoop(object):
                                  error_in_error_handling_message)
                 reraise_as(e)
             finally:
-                if self.log.current_entry['training_finished']:
+                if self.log.current_entry.get('training_finished', False):
                     self._run_extensions('after_training')
                 self._restore_signal_handlers()
 

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -256,11 +256,11 @@ class MainLoop(object):
         # In case when keyboard interrupt is handled right at the end of
         # the iteration the corresponding log record can be found only in
         # the previous row.
-        if (self.log.current_entry['training_finish_requested'] or
-                self.status['batch_interrupt_received']):
+        if (self.log.current_entry.get('training_finish_requested', False) or
+                self.status.get('batch_interrupt_received', False)):
             raise TrainingFinish
         if (level == 'epoch' and
-                self.status['epoch_interrupt_received']):
+                self.status.get('epoch_interrupt_received', False)):
             raise TrainingFinish
 
     def _handle_epoch_interrupt(self, signal_number, frame):

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -86,10 +86,6 @@ class MainLoop(object):
                  model=None, log=None, extensions=None):
         if log is None:
             log = TrainingLog()
-        log.status.exclude.extend(['training_started', 'epoch_started',
-                                   'epoch_interrupt_received',
-                                   'batch_interrupt_received',
-                                   'received_first_batch', 'epoch_ends'])
         if extensions is None:
             extensions = []
 
@@ -218,7 +214,7 @@ class MainLoop(object):
             pass
         self.status['epoch_started'] = False
         self.status['epochs_done'] += 1
-        self.status['epoch_ends'].append(self.status['iterations_done'])
+        self.log.current_entry['epoch_ended'] = True
         self._run_extensions('after_epoch')
         self._check_finish_training('epoch')
         return True

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -85,7 +85,12 @@ class MainLoop(object):
     def __init__(self, algorithm, data_stream,
                  model=None, log=None, extensions=None):
         if not log:
-            log = TrainingLog()
+            log = TrainingLog(
+                status_exclude=['training_started', 'epoch_started',
+                                'epoch_interrupt_received',
+                                'batch_interrupt_received',
+                                'received_first_batch', 'epoch_ends']
+            )
         if not extensions:
             extensions = []
 
@@ -96,10 +101,10 @@ class MainLoop(object):
 
         self._model = model
 
-        self.status._training_started = False
-        self.status._epoch_started = False
-        self.status._epoch_interrupt_received = False
-        self.status._batch_interrupt_received = False
+        self.status['training_started'] = False
+        self.status['epoch_started'] = False
+        self.status['epoch_interrupt_received'] = False
+        self.status['batch_interrupt_received'] = False
 
     @property
     def model(self):
@@ -150,26 +155,26 @@ class MainLoop(object):
                 signal.SIGTERM, self._handle_batch_interrupt)
             try:
                 logger.info("Entered the main loop")
-                if not self.status._training_started:
+                if not self.status['training_started']:
                     for extension in self.extensions:
                         extension.main_loop = self
                     self._run_extensions('before_training')
                     self.algorithm.initialize()
-                    self.status._training_started = True
+                    self.status['training_started'] = True
                 # We can not write "else:" here because extensions
                 # called "before_training" could have changed the status
                 # of the main loop.
-                if self.log.status.iterations_done > 0:
+                if self.log.status['iterations_done'] > 0:
                     self._run_extensions('on_resumption')
-                    self.status._epoch_interrupt_received = False
-                    self.status._batch_interrupt_received = False
+                    self.status['epoch_interrupt_received'] = False
+                    self.status['batch_interrupt_received'] = False
                 while self._run_epoch():
                     pass
             except TrainingFinish:
-                self.log.current_row.training_finished = True
+                self.log.current_row['training_finished'] = True
             except Exception as e:
                 self._restore_signal_handlers()
-                self.log.current_row.got_exception = traceback.format_exc(e)
+                self.log.current_row['got_exception'] = traceback.format_exc(e)
                 logger.error("Error occured during training." + error_message)
                 try:
                     self._run_extensions('on_error')
@@ -179,7 +184,7 @@ class MainLoop(object):
                                  error_in_error_handling_message)
                 reraise_as(e)
             finally:
-                if self.log.current_row.training_finished:
+                if self.log.current_row['training_finished']:
                     self._run_extensions('after_training')
                 self._restore_signal_handlers()
 
@@ -200,20 +205,20 @@ class MainLoop(object):
                        if extension.name == name], singleton=True)
 
     def _run_epoch(self):
-        if not self.status._epoch_started:
+        if not self.status['epoch_started']:
             try:
-                self.log.status._received_first_batch = False
+                self.log.status['received_first_batch'] = False
                 self.epoch_iterator = (self.data_stream.
                                        get_epoch_iterator(as_dict=True))
             except StopIteration:
                 return False
-            self.status._epoch_started = True
+            self.status['epoch_started'] = True
             self._run_extensions('before_epoch')
         while self._run_iteration():
             pass
-        self.status._epoch_started = False
-        self.status.epochs_done += 1
-        self.status._epoch_ends.append(self.status.iterations_done)
+        self.status['epoch_started'] = False
+        self.status['epochs_done'] += 1
+        self.status['epoch_ends'].append(self.status['iterations_done'])
         self._run_extensions('after_epoch')
         self._check_finish_training('epoch')
         return True
@@ -222,13 +227,13 @@ class MainLoop(object):
         try:
             batch = next(self.epoch_iterator)
         except StopIteration:
-            if not self.log.status._received_first_batch:
+            if not self.log.status['received_first_batch']:
                 reraise_as(ValueError("epoch iterator yielded zero batches"))
             return False
-        self.log.status._received_first_batch = True
+        self.log.status['received_first_batch'] = True
         self._run_extensions('before_batch', batch)
         self.algorithm.process_batch(batch)
-        self.status.iterations_done += 1
+        self.status['iterations_done'] += 1
         self._run_extensions('after_batch', batch)
         self._check_finish_training('batch')
         return True
@@ -250,11 +255,11 @@ class MainLoop(object):
         # In case when keyboard interrupt is handled right at the end of
         # the iteration the corresponding log record can be found only in
         # the previous row.
-        if (self.log.current_row.training_finish_requested or
-                self.status._batch_interrupt_received):
+        if (self.log.current_row['training_finish_requested'] or
+                self.status['batch_interrupt_received']):
             raise TrainingFinish
         if (level == 'epoch' and
-                self.status._epoch_interrupt_received):
+                self.status['epoch_interrupt_received']):
             raise TrainingFinish
 
     def _handle_epoch_interrupt(self, signal_number, frame):
@@ -262,20 +267,20 @@ class MainLoop(object):
         logger.warning('Received epoch interrupt signal.' +
                        epoch_interrupt_message)
         signal.signal(signal.SIGINT, self._handle_batch_interrupt)
-        self.log.current_row.epoch_interrupt_received = True
+        self.log.current_row['epoch_interrupt_received'] = True
         # Add a record to the status. Unlike the log record it will be
         # easy to access at later iterations.
-        self.status._epoch_interrupt_received = True
+        self.status['epoch_interrupt_received'] = True
 
     def _handle_batch_interrupt(self, signal_number, frame):
         # After 2nd CTRL + C or SIGTERM signal (from cluster) finish batch
         self._restore_signal_handlers()
         logger.warning('Received batch interrupt signal.' +
                        batch_interrupt_message)
-        self.log.current_row.batch_interrupt_received = True
+        self.log.current_row['batch_interrupt_received'] = True
         # Add a record to the status. Unlike the log record it will be
         # easy to access at later iterations.
-        self.status._batch_interrupt_received = True
+        self.status['batch_interrupt_received'] = True
 
     def _restore_signal_handlers(self):
         signal.signal(signal.SIGINT, self.original_sigint_handler)

--- a/blocks/scripts/plot.py
+++ b/blocks/scripts/plot.py
@@ -10,7 +10,7 @@ from functools import reduce
 
 from blocks import config
 from blocks.utils import change_recursion_limit
-from blocks.log import AbstractTrainingLog
+from blocks.log import TrainingLog
 from blocks.main_loop import MainLoop
 
 try:
@@ -24,7 +24,7 @@ def load_log(fname):
     """Load a :claas:`TrainingLog` object from disk.
 
     This function automatically handles various file formats that contain
-    an instance of an :claas:`AbstractTrainingLog`. This includes a pickled
+    an instance of an :claas:`TrainingLog`. This includes a pickled
     Log object, a pickled :claas:`MainLoop` or an experiment dump (TODO).
 
     """
@@ -33,7 +33,7 @@ def load_log(fname):
             from_disk = cPickle.load(f)
         # TODO: Load "dumped" experiments
 
-    if isinstance(from_disk, AbstractTrainingLog):
+    if isinstance(from_disk, TrainingLog):
         log = from_disk
     elif isinstance(from_disk, MainLoop):
         log = from_disk.log

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -22,6 +22,7 @@ from blocks.extensions.monitoring import (DataStreamMonitoring,
                                           TrainingDataMonitoring)
 from blocks.extensions.plot import Plot
 from blocks.main_loop import MainLoop
+from blocks.log import TrainingLog
 
 
 def main(save_to, num_epochs):
@@ -51,10 +52,9 @@ def main(save_to, num_epochs):
         DataStream(mnist_train,
                    iteration_scheme=SequentialScheme(
                        mnist_train.num_examples, 50)),
+        log=TrainingLog(backend='mongodb'),
         model=Model(cost),
-        extensions=[Timing(),
-                    FinishAfter(after_n_epochs=num_epochs),
-                    DataStreamMonitoring(
+        extensions=[DataStreamMonitoring(
                         [cost, error_rate],
                         DataStream(mnist_test,
                                    iteration_scheme=SequentialScheme(
@@ -65,13 +65,6 @@ def main(save_to, num_epochs):
                          aggregation.mean(algorithm.total_gradient_norm)],
                         prefix="train",
                         after_epoch=True),
-                    Checkpoint(save_to),
-                    Plot(
-                        'MNIST example',
-                        channels=[
-                            ['test_final_cost',
-                             'test_misclassificationrate_apply_error_rate'],
-                            ['train_total_gradient_norm']]),
                     Printing()])
     main_loop.run()
 

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -82,7 +82,7 @@ def _filter_long(data):
 
 
 def _is_nan(log):
-    return math.isnan(log.current_row['total_gradient_norm'])
+    return math.isnan(log.current_entry['total_gradient_norm'])
 
 
 class WordReverser(Initializable):

--- a/examples/reverse_words/__init__.py
+++ b/examples/reverse_words/__init__.py
@@ -82,7 +82,7 @@ def _filter_long(data):
 
 
 def _is_nan(log):
-    return math.isnan(log.current_row.total_gradient_norm)
+    return math.isnan(log.current_row['total_gradient_norm'])
 
 
 class WordReverser(Initializable):

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -33,7 +33,7 @@ def test_training_data_monitoring():
     class TrueCostExtension(TrainingExtension):
 
         def before_batch(self, data):
-            self.main_loop.log.current_row.true_cost = (
+            self.main_loop.log.current_row['true_cost'] = (
                 ((W.get_value() * data["features"]).sum() -
                  data["targets"]) ** 2)
 
@@ -52,19 +52,19 @@ def test_training_data_monitoring():
     main_loop.run()
 
     # Check monitoring of a shared varible
-    assert_allclose(main_loop.log.current_row.train1_V, 7.0)
+    assert_allclose(main_loop.log.current_row['train1_V'], 7.0)
 
     for i in range(n_batches):
         # The ground truth is written to the log before the batch is
         # processed, where as the extension writes after the batch is
         # processed. This is why the iteration numbers differs here.
-        assert_allclose(main_loop.log[i].true_cost,
-                        main_loop.log[i + 1].train1_cost)
+        assert_allclose(main_loop.log[i]['true_cost'],
+                        main_loop.log[i + 1]['train1_cost'])
     assert_allclose(
-        main_loop.log[n_batches].train2_cost,
-        sum([main_loop.log[i].true_cost
+        main_loop.log[n_batches]['train2_cost'],
+        sum([main_loop.log[i]['true_cost']
              for i in range(n_batches)]) / n_batches)
     assert_allclose(
-        main_loop.log[n_batches].train2_W_sum,
-        sum([main_loop.log[i].train1_W_sum
+        main_loop.log[n_batches]['train2_W_sum'],
+        sum([main_loop.log[i]['train1_W_sum']
              for i in range(1, n_batches + 1)]) / n_batches)

--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -33,7 +33,7 @@ def test_training_data_monitoring():
     class TrueCostExtension(TrainingExtension):
 
         def before_batch(self, data):
-            self.main_loop.log.current_row['true_cost'] = (
+            self.main_loop.log.current_entry['true_cost'] = (
                 ((W.get_value() * data["features"]).sum() -
                  data["targets"]) ** 2)
 
@@ -52,7 +52,7 @@ def test_training_data_monitoring():
     main_loop.run()
 
     # Check monitoring of a shared varible
-    assert_allclose(main_loop.log.current_row['train1_V'], 7.0)
+    assert_allclose(main_loop.log.current_entry['train1_V'], 7.0)
 
     for i in range(n_batches):
         # The ground truth is written to the log before the batch is

--- a/tests/extensions/test_timing.py
+++ b/tests/extensions/test_timing.py
@@ -16,33 +16,33 @@ def test_timing():
     # Start epoch 1
     now += 2
     timing.before_epoch()
-    assert ml.log[0].initialization_took == 2
-    ml.log.status._epoch_started = True
+    assert ml.log[0]['initialization_took'] == 2
+    ml.log.status['epoch_started'] = True
 
     # Batch 1
     timing.before_batch(None)
     now += 7
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[1].iteration_took == 7
+    assert ml.log[1]['iteration_took'] == 7
 
     # Batch 2
     timing.before_batch(None)
     now += 8
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[2].iteration_took == 8
+    assert ml.log[2]['iteration_took'] == 8
 
     # Epoch 1 is done
-    ml.log.status.epochs_done += 1
+    ml.log.status['epochs_done'] += 1
     timing.after_epoch()
-    assert ml.log[2].epoch_took == 15
-    assert ml.log[2].total_took == 17
+    assert ml.log[2]['epoch_took'] == 15
+    assert ml.log[2]['total_took'] == 17
 
     # Finish training
     now += 1
     timing.after_training()
-    assert ml.log[2].final_total_took == 18
+    assert ml.log[2]['final_total_took'] == 18
 
     # Resume training
     now = 0
@@ -50,15 +50,15 @@ def test_timing():
 
     # Start epoch 2
     timing.before_epoch()
-    assert ml.log[2].initialization_took is None
+    assert ml.log[2]['initialization_took'] is None
 
     # Batch 3
     timing.before_batch(None)
     now += 6
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[3].iteration_took == 6
-    assert ml.log[3].total_took == 24
+    assert ml.log[3]['iteration_took'] == 6
+    assert ml.log[3]['total_took'] == 24
 
     # Finish training before the end of the current epoch
     timing.after_training()
@@ -70,15 +70,15 @@ def test_timing():
     # Batch 4
     timing.before_batch(None)
     now += 2
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[4].iteration_took == 2
-    assert ml.log[4].total_took == 26
+    assert ml.log[4]['iteration_took'] == 2
+    assert ml.log[4]['total_took'] == 26
 
     # Epoch 2 is done
-    ml.log.status.epochs_done += 1
+    ml.log.status['epochs_done'] += 1
     timing.after_epoch()
-    assert ml.log[4].epoch_took == 8
+    assert ml.log[4]['epoch_took'] == 8
 
     # Start epoch 3
     timing.before_epoch()
@@ -86,12 +86,12 @@ def test_timing():
     # Batch 5
     timing.before_batch(None)
     now += 5
-    ml.log.status.iterations_done += 1
+    ml.log.status['iterations_done'] += 1
     timing.after_batch(None)
-    assert ml.log[5].iteration_took == 5
-    assert ml.log[5].total_took == 31
+    assert ml.log[5]['iteration_took'] == 5
+    assert ml.log[5]['total_took'] == 31
 
     # Epoch 3 is done
-    ml.log.status.epochs_done += 1
+    ml.log.status['epochs_done'] += 1
     timing.after_epoch()
-    assert ml.log[5].epoch_took == 5
+    assert ml.log[5]['epoch_took'] == 5

--- a/tests/extensions/test_timing.py
+++ b/tests/extensions/test_timing.py
@@ -50,7 +50,7 @@ def test_timing():
 
     # Start epoch 2
     timing.before_epoch()
-    assert ml.log[2]['initialization_took'] is None
+    assert 'initialization_took' not in ml.log[2]
 
     # Batch 3
     timing.before_batch(None)

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -101,13 +101,13 @@ def test_track_the_best():
     main_loop.log.current_entry['cost'] = 6
     extension.dispatch('after_batch')
     assert main_loop.status['best_cost'] == 5
-    assert main_loop.log.current_entry['cost_best_so_far'] is None
+    assert 'cost_best_so_far' not in main_loop.log.current_entry
 
     main_loop.status['iterations_done'] += 1
     main_loop.log.current_entry['cost'] = 5
     extension.dispatch('after_batch')
     assert main_loop.status['best_cost'] == 5
-    assert main_loop.log.current_entry['cost_best_so_far'] is None
+    assert 'cost_best_so_far' not in main_loop.log.current_entry
 
     main_loop.status['iterations_done'] += 1
     main_loop.log.current_entry['cost'] = 4

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -92,34 +92,34 @@ def test_track_the_best():
     extension.main_loop = main_loop
 
     main_loop.status['iterations_done'] += 1
-    main_loop.log.current_row['cost'] = 5
+    main_loop.log.current_entry['cost'] = 5
     extension.dispatch('after_batch')
     assert main_loop.status['best_cost'] == 5
-    assert main_loop.log.current_row['cost_best_so_far']
+    assert main_loop.log.current_entry['cost_best_so_far']
 
     main_loop.status['iterations_done'] += 1
-    main_loop.log.current_row['cost'] = 6
+    main_loop.log.current_entry['cost'] = 6
     extension.dispatch('after_batch')
     assert main_loop.status['best_cost'] == 5
-    assert main_loop.log.current_row['cost_best_so_far'] is None
+    assert main_loop.log.current_entry['cost_best_so_far'] is None
 
     main_loop.status['iterations_done'] += 1
-    main_loop.log.current_row['cost'] = 5
+    main_loop.log.current_entry['cost'] = 5
     extension.dispatch('after_batch')
     assert main_loop.status['best_cost'] == 5
-    assert main_loop.log.current_row['cost_best_so_far'] is None
+    assert main_loop.log.current_entry['cost_best_so_far'] is None
 
     main_loop.status['iterations_done'] += 1
-    main_loop.log.current_row['cost'] = 4
+    main_loop.log.current_entry['cost'] = 4
     extension.dispatch('after_batch')
     assert main_loop.status['best_cost'] == 4
-    assert main_loop.log.current_row['cost_best_so_far']
+    assert main_loop.log.current_entry['cost_best_so_far']
 
 
 class WriteCostExtension(TrainingExtension):
 
     def after_batch(self, batch):
-        self.main_loop.log.current_row['cost'] = abs(
+        self.main_loop.log.current_entry['cost'] = abs(
             self.main_loop.log.status['iterations_done'] - 5) + 3
 
 

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -91,36 +91,36 @@ def test_track_the_best():
     extension = TrackTheBest("cost")
     extension.main_loop = main_loop
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 5
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 5
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 5
+    assert main_loop.status['best_cost'] == 5
     assert main_loop.log.current_row['cost_best_so_far']
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 6
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 6
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 5
+    assert main_loop.status['best_cost'] == 5
     assert main_loop.log.current_row['cost_best_so_far'] is None
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 5
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 5
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 5
+    assert main_loop.status['best_cost'] == 5
     assert main_loop.log.current_row['cost_best_so_far'] is None
 
-    main_loop.status.iterations_done += 1
-    main_loop.log.current_row.cost = 4
+    main_loop.status['iterations_done'] += 1
+    main_loop.log.current_row['cost'] = 4
     extension.dispatch('after_batch')
-    assert main_loop.status.best_cost == 4
+    assert main_loop.status['best_cost'] == 4
     assert main_loop.log.current_row['cost_best_so_far']
 
 
 class WriteCostExtension(TrainingExtension):
 
     def after_batch(self, batch):
-        self.main_loop.log.current_row.cost = abs(
-            self.main_loop.log.status.iterations_done - 5) + 3
+        self.main_loop.log.current_row['cost'] = abs(
+            self.main_loop.log.status['iterations_done'] - 5) + 3
 
 
 def test_save_the_best():
@@ -139,12 +139,12 @@ def test_save_the_best():
                             (dst_best.name,))])
         main_loop.run()
 
-        assert main_loop.log[4].saved_to == (dst.name, dst_best.name)
-        assert main_loop.log[5].saved_to == (dst.name, dst_best.name)
-        assert main_loop.log[6].saved_to == (dst.name,)
+        assert main_loop.log[4]['saved_to'] == (dst.name, dst_best.name)
+        assert main_loop.log[5]['saved_to'] == (dst.name, dst_best.name)
+        assert main_loop.log[6]['saved_to'] == (dst.name,)
         with open(dst_best.name, 'rb') as src:
-            assert cPickle.load(src).log.status.iterations_done == 5
+            assert cPickle.load(src).log.status['iterations_done'] == 5
         root, ext = os.path.splitext(dst_best.name)
         log_path = root + "_log" + ext
         with open(log_path, 'rb') as src:
-            assert cPickle.load(src).status.iterations_done == 5
+            assert cPickle.load(src).status['iterations_done'] == 5

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -139,9 +139,9 @@ def test_save_the_best():
                             (dst_best.name,))])
         main_loop.run()
 
-        assert main_loop.log[4]['saved_to'] == (dst.name, dst_best.name)
-        assert main_loop.log[5]['saved_to'] == (dst.name, dst_best.name)
-        assert main_loop.log[6]['saved_to'] == (dst.name,)
+        assert main_loop.log[4]['saved_to'] == [dst.name, dst_best.name]
+        assert main_loop.log[5]['saved_to'] == [dst.name, dst_best.name]
+        assert main_loop.log[6]['saved_to'] == [dst.name]
         with open(dst_best.name, 'rb') as src:
             assert cPickle.load(src).log.status['iterations_done'] == 5
         root, ext = os.path.splitext(dst_best.name)

--- a/tests/scripts/test_plot.py
+++ b/tests/scripts/test_plot.py
@@ -49,7 +49,7 @@ def test_load_log():
         f.flush()
 
         log2 = plot.load_log(f.name)
-        assert log2[0].channel0 == 0
+        assert log2[0]['channel0'] == 0
 
 
 @silence_printing

--- a/tests/scripts/test_plot.py
+++ b/tests/scripts/test_plot.py
@@ -38,7 +38,7 @@ def test_load_log():
         f.flush()
 
         log2 = plot.load_log(f.name)
-        assert log2[0].channel0 == 0
+        assert log2[0]['channel0'] == 0
 
     # test MainLoop pickles
     main_loop = MainLoop(model=None, data_stream=None,

--- a/tests/scripts/test_plot.py
+++ b/tests/scripts/test_plot.py
@@ -30,7 +30,7 @@ def some_experiments():
 
 def test_load_log():
     log = TrainingLog()
-    log[0].channel0 = 0
+    log[0]['channel0'] = 0
 
     # test simple TrainingLog pickles
     with tempfile.NamedTemporaryFile() as f:

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -50,8 +50,8 @@ def test_main_loop_dump_manager():
     folder2 = tempfile.mkdtemp()
 
     main_loop1 = sqrt_example(folder, 17)
-    assert main_loop1.log.status.epochs_done == 3
-    assert main_loop1.log.status.iterations_done == 17
+    assert main_loop1.log.status['epochs_done'] == 3
+    assert main_loop1.log.status['iterations_done'] == 17
 
     # Test loading from the folder where `main_loop` is saved
     main_loop2 = sqrt_example(folder2, 1)
@@ -65,9 +65,9 @@ def test_main_loop_dump_manager():
     # Continue until 33 iterations are done
     main_loop2.find_extension("FinishAfter").set_conditions(after_n_batches=33)
     main_loop2.run()
-    assert main_loop2.log.status.iterations_done == 33
+    assert main_loop2.log.status['iterations_done'] == 33
 
     # Compare with a main loop after continuous 33 iterations
     main_loop3 = sqrt_example(folder, 33)
-    assert main_loop3.log.status.iterations_done == 33
+    assert main_loop3.log.status['iterations_done'] == 33
     assert_equal(main_loop2, main_loop3, check_log=False)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,7 +30,7 @@ def test_mnist():
         main_loop.find_extension("FinishAfter").set_conditions(
             after_n_epochs=2)
         main_loop.run()
-        assert main_loop.log.status.epochs_done == 2
+        assert main_loop.log.status['epochs_done'] == 2
 
 
 @silence_printing

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -5,23 +5,13 @@ def test_training_log():
     log = TrainingLog()
 
     # test basic writing capabilities
-    log[0].field = 45
-    assert log[0].field == 45
-    assert log[1].field is None
-    assert log.current_row.field == 45
-    log.status.iterations_done += 1
-    assert log.status.iterations_done == 1
-    assert log.previous_row.field == 45
-
-    # test default values mechanism
-    log.set_default_value('flag', True)
-    assert log[0].flag
-    log[1].flag = False
-    assert not log[1].flag
+    log[0]['field'] = 45
+    assert log[0]['field'] == 45
+    assert log[1]['field'] is None
+    assert log.current_row['field'] == 45
+    log.status['iterations_done'] += 1
+    assert log.status['iterations_done'] == 1
+    assert log.previous_row['field'] == 45
 
     # test iteration
     assert len(list(log)) == 2
-    df = log.to_dataframe()
-    assert list(sorted(df.columns)) == ["field", "flag"]
-    assert df.flag[1] is False
-    assert df.field[0] == 45

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -8,10 +8,10 @@ def test_training_log():
     log[0]['field'] = 45
     assert log[0]['field'] == 45
     assert log[1]['field'] is None
-    assert log.current_row['field'] == 45
+    assert log.current_entry['field'] == 45
     log.status['iterations_done'] += 1
     assert log.status['iterations_done'] == 1
-    assert log.previous_row['field'] == 45
+    assert log.previous_entry['field'] == 45
 
     # test iteration
     assert len(list(log)) == 2

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,3 +1,8 @@
+from operator import itemgetter
+
+from numpy.testing import assert_raises
+from six.moves import cPickle
+
 from blocks.log import TrainingLog
 
 
@@ -12,5 +17,24 @@ def test_training_log():
     assert log.status['iterations_done'] == 1
     assert log.previous_entry['field'] == 45
 
+    log.current_entry['field2'] = ['foo']
+    assert log[1]['field2'] == ['foo']
+    log.current_entry['field2'] = log.current_entry.get('field2', []) + ['bar']
+    assert log.current_entry['field2'] == ['foo', 'bar']
+
     # test iteration
-    assert len(list(log)) == 1
+    assert len(log) == 2
+
+    # test pickling
+    log = cPickle.loads(cPickle.dumps(log))
+    assert log.current_entry['field2'] == ['foo', 'bar']
+    assert len(log) == 2
+    assert log[0]['field'] == 45
+
+    # test defaults
+    assert log[2] == {}
+    assert_raises(KeyError, itemgetter('foo'), log[2])
+
+    # test mapping interface
+    assert list(log[0].items()) == [('field', 45)]
+    assert len(log[0]) == 1

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -7,7 +7,6 @@ def test_training_log():
     # test basic writing capabilities
     log[0]['field'] = 45
     assert log[0]['field'] == 45
-    assert log[1]['field'] is None
     assert log.current_entry['field'] == 45
     log.status['iterations_done'] += 1
     assert log.status['iterations_done'] == 1

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -13,4 +13,4 @@ def test_training_log():
     assert log.previous_entry['field'] == 45
 
     # test iteration
-    assert len(list(log)) == 2
+    assert len(list(log)) == 1

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -43,7 +43,7 @@ def test_main_loop():
 
     assert main_loop.log.status['iterations_done'] == 5
     assert main_loop.log.status['epoch_ends'] == [3, 5]
-    assert len(list(main_loop.log)) == 7
+    assert len(list(main_loop.log)) == 5
     for i in range(1, 6):
         assert main_loop.log[i]['batch'] == dict(data=i)
 

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -10,7 +10,7 @@ from tests import MockAlgorithm
 class WriteBatchExtension(TrainingExtension):
     """Writes data saved by MockAlgorithm to the log."""
     def after_batch(self, _):
-        self.main_loop.log.current_row['batch'] = \
+        self.main_loop.log.current_entry['batch'] = \
             self.main_loop.algorithm.batch
 
 

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -42,7 +42,8 @@ def test_main_loop():
     main_loop.run()
 
     assert main_loop.log.status['iterations_done'] == 5
-    assert main_loop.log.status['epoch_ends'] == [3, 5]
+    assert [key for key, value in main_loop.log.items()
+            if 'epoch_ended' in value] == [3, 5]
     assert len(list(main_loop.log)) == 5
     for i in range(1, 6):
         assert main_loop.log[i]['batch'] == dict(data=i)

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -10,7 +10,7 @@ from tests import MockAlgorithm
 class WriteBatchExtension(TrainingExtension):
     """Writes data saved by MockAlgorithm to the log."""
     def after_batch(self, _):
-        self.main_loop.log.current_row.batch = self.main_loop.algorithm.batch
+        self.main_loop.log.current_row['batch'] = self.main_loop.algorithm.batch
 
 
 def test_main_loop():
@@ -34,17 +34,17 @@ def test_main_loop():
 
     finish_extension = FinishAfter()
     finish_extension.add_condition(
-        'after_epoch', predicate=lambda log: log.status.epochs_done == 2)
+        'after_epoch', predicate=lambda log: log.status['epochs_done'] == 2)
     main_loop = MainLoop(MockAlgorithm(), TestDataStream(),
                          extensions=[WriteBatchExtension(),
                                      finish_extension])
     main_loop.run()
 
-    assert main_loop.log.status.iterations_done == 5
-    assert main_loop.log.status._epoch_ends == [3, 5]
+    assert main_loop.log.status['iterations_done'] == 5
+    assert main_loop.log.status['epoch_ends'] == [3, 5]
     assert len(list(main_loop.log)) == 7
     for i in range(1, 6):
-        assert main_loop.log[i].batch == dict(data=i)
+        assert main_loop.log[i]['batch'] == dict(data=i)
 
 
 def test_training_resumption():
@@ -55,7 +55,7 @@ def test_training_resumption():
             extensions=[WriteBatchExtension(),
                         FinishAfter(after_n_batches=14)])
         main_loop.run()
-        assert main_loop.log.status.iterations_done == 14
+        assert main_loop.log.status['iterations_done'] == 14
 
         if with_serialization:
             main_loop = cPickle.loads(cPickle.dumps(main_loop))
@@ -65,12 +65,12 @@ def test_training_resumption():
              if isinstance(ext, FinishAfter)], singleton=True)
         finish_after.add_condition(
             "after_batch",
-            predicate=lambda log: log.status.iterations_done == 27)
+            predicate=lambda log: log.status['iterations_done'] == 27)
         main_loop.run()
-        assert main_loop.log.status.iterations_done == 27
-        assert main_loop.log.status.epochs_done == 2
+        assert main_loop.log.status['iterations_done'] == 27
+        assert main_loop.log.status['epochs_done'] == 2
         for i in range(27):
-            assert main_loop.log[i + 1].batch == {"data": i % 10}
+            assert main_loop.log[i + 1]['batch'] == {"data": i % 10}
 
     do_test(False)
     do_test(True)

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -10,7 +10,8 @@ from tests import MockAlgorithm
 class WriteBatchExtension(TrainingExtension):
     """Writes data saved by MockAlgorithm to the log."""
     def after_batch(self, _):
-        self.main_loop.log.current_row['batch'] = self.main_loop.algorithm.batch
+        self.main_loop.log.current_row['batch'] = \
+            self.main_loop.algorithm.batch
 
 
 def test_main_loop():


### PR DESCRIPTION
Fixes #470.

I started to implement a log with MongoDB as a backend (as suggested by @dwf). MongoDB has a nice Python library--I'm using version 3.0b0 of PyMongo which isn't on PyPI yet if you want to try it--and its document structure fits the log quite easily. I think that the ability to host the database on an external server could be very beneficial later on e.g. when running experiments on clusters (sending results back to your computer) and for analysis (a web server or Bokeh could query the database server to read and present results, at LISA we could even run a dedicated MongoDB server for this, like we have with PostgreSQL).

I started with a rewrite of the `TrainingLog` class though because there were *a lot* of abstractions in there, which seemed to just complicate implementing a new backend. Forcing rows to be a separate object seems a bit much, and the possibility to set default values seems completely unused. I would suggest to switching to simplest data structure possible: A nested, ordered dictionary.

Considering that the log gets created by the `MainLoop` class it might be easier to delegate from a single `TrainingLog` class to different log handlers (`DefaultOrderedDict` and `MongoLog`) instead of them being their own proper classes, so that's what I did.

Performance-wise a local MongoDB database seems to do pretty well with inserting keys (approx. 300 µs). If logging to an external server turns out to be too slow, it seems we can always switch to asynchronous calls with Gevent easily.

- [x] Add docstrings
- [ ] Tests
- [ ] Support for multiple logs in one database
- [x] Change to new syntax in other files