### PR TITLE
WIP: New bricks

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -1,5 +1,6 @@
 """The interface of bricks and some simple implementations."""
 import logging
+from abc import ABCMeta
 
 import numpy
 from six import add_metaclass
@@ -9,7 +10,7 @@ from toolz import interleave
 from picklable_itertools.extras import equizip
 
 from blocks import config
-from blocks.bricks.base import application, _Brick, Brick, lazy
+from blocks.bricks.base import application, Brick, lazy
 from blocks.roles import add_role, WEIGHT, BIAS
 from blocks.utils import pack, shared_floatx_nans
 
@@ -428,7 +429,7 @@ class LinearMaxout(Initializable, Feedforward):
         return output
 
 
-class ActivationDocumentation(_Brick):
+class ActivationDocumentation(ABCMeta):
     """Dynamically adds documentation to activations.
 
     Notes

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -139,7 +139,8 @@ class Initializable(Brick):
     def rng(self, rng):
         self._rng = rng
 
-    def _push_initialization_config(self):
+    @initialization_push
+    def push_initialization_config(self):
         for child in self.children:
             if isinstance(child, Initializable):
                 child.rng = self.rng
@@ -409,7 +410,8 @@ class LinearMaxout(Initializable, Feedforward):
     def input_dim(self, value):
         self.linear.input_dim = value
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.linear.output_dim = self.output_dim * self.num_pieces
         self.maxout.num_pieces = self.num_pieces
 
@@ -671,7 +673,8 @@ class MLP(Sequence, Initializable, Feedforward):
     def output_dim(self, value):
         self.dims[-1] = value
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         if not len(self.dims) - 1 == len(self.linear_transformations):
             raise ValueError
         for input_dim, output_dim, layer in \

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -100,7 +100,7 @@ class Initializable(Brick):
     has_biases = True
     seed_rng = numpy.random.RandomState(config.default_seed)
 
-    @lazy
+    @lazy(initialization=['weights_init'])
     def __init__(self, weights_init, biases_init=None, use_bias=True,
                  seed=None, **kwargs):
         super(Initializable, self).__init__(**kwargs)
@@ -201,7 +201,7 @@ class Linear(Initializable, Feedforward):
     .. math:: f(\mathbf{x}) = \mathbf{W}\mathbf{x} + \mathbf{b}
 
     """
-    @lazy
+    @lazy(allocation=['input_dim', 'output_dim'])
     def __init__(self, input_dim, output_dim, **kwargs):
         super(Linear, self).__init__(**kwargs)
         self.input_dim = input_dim
@@ -268,7 +268,7 @@ class Linear(Initializable, Feedforward):
 
 class Bias(Feedforward, Initializable):
     """Add a bias (i.e. sum with a vector)."""
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, **kwargs):
         super(Bias, self).__init__(**kwargs)
         self.dim = dim
@@ -335,7 +335,7 @@ class Maxout(Brick):
     for each output dimension the result with the highest value.
 
     """
-    @lazy
+    @lazy(allocation=['num_pieces'])
     def __init__(self, num_pieces, **kwargs):
         super(Maxout, self).__init__(**kwargs)
         self.num_pieces = num_pieces
@@ -385,7 +385,7 @@ class LinearMaxout(Initializable, Feedforward):
     See :class:`Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['input_dim', 'output_dim', 'num_pieces'])
     def __init__(self, input_dim, output_dim, num_pieces, **kwargs):
         super(LinearMaxout, self).__init__(**kwargs)
         self.linear = Linear()
@@ -631,7 +631,7 @@ class MLP(Sequence, Initializable, Feedforward):
     >>> mlp.initialize()
 
     """
-    @lazy
+    @lazy(allocation=['dims'])
     def __init__(self, activations, dims, **kwargs):
         self.activations = activations
 

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -10,7 +10,9 @@ from toolz import interleave
 from picklable_itertools.extras import equizip
 
 from blocks import config
-from blocks.bricks.base import application, Brick, lazy
+from blocks.bricks.base import (application, Brick, lazy, allocation,
+                                initialization, allocation_push,
+                                initialization_push)
 from blocks.roles import add_role, WEIGHT, BIAS
 from blocks.utils import pack, shared_floatx_nans
 

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -212,31 +212,31 @@ class Linear(Initializable, Feedforward):
 
     @property
     def W(self):
-        return self.params[0]
+        return self.parameters[0]
 
     @property
     def b(self):
-        return self.params[1]
+        return self.parameters[1]
 
     @allocation
     def allocate(self):
         W = shared_floatx_nans((self.input_dim, self.output_dim), name='W')
         add_role(W, WEIGHT)
-        self.params.append(W)
+        self.parameters.append(W)
         self.add_auxiliary_variable(W.norm(2), name='W_norm')
         if self.use_bias:
             b = shared_floatx_nans((self.output_dim,), name='b')
             add_role(b, BIAS)
-            self.params.append(b)
+            self.parameters.append(b)
             self.add_auxiliary_variable(b.norm(2), name='b_norm')
 
     @initialization
     def initialize(self):
         if self.use_bias:
-            W, b = self.params
+            W, b = self.parameters
             self.biases_init.initialize(b, self.rng)
         else:
-            W, = self.params
+            W, = self.parameters
         self.weights_init.initialize(W, self.rng)
 
     @application(inputs=['input_'], outputs=['output'])
@@ -255,9 +255,9 @@ class Linear(Initializable, Feedforward):
 
         """
         if self.use_bias:
-            W, b = self.params
+            W, b = self.parameters
         else:
-            W, = self.params
+            W, = self.parameters
         output = tensor.dot(input_, W)
         if self.use_bias:
             output += b
@@ -282,11 +282,11 @@ class Bias(Feedforward, Initializable):
     def allocate(self):
         b = shared_floatx_nans((self.output_dim,), name='b')
         add_role(b, BIAS)
-        self.params.append(b)
+        self.parameters.append(b)
 
     @initialization
     def initialize(self):
-        b, = self.params
+        b, = self.parameters
         self.biases_init.initialize(b, self.rng)
 
     @application(inputs=['input_'], outputs=['output'])
@@ -304,7 +304,7 @@ class Bias(Feedforward, Initializable):
             The transformed input plus optional bias
 
         """
-        b, = self.params
+        b, = self.parameters
         return input_ + b
 
     def get_dim(self, name):

--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -215,7 +215,8 @@ class Linear(Initializable, Feedforward):
     def b(self):
         return self.params[1]
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         W = shared_floatx_nans((self.input_dim, self.output_dim), name='W')
         add_role(W, WEIGHT)
         self.params.append(W)
@@ -226,7 +227,8 @@ class Linear(Initializable, Feedforward):
             self.params.append(b)
             self.add_auxiliary_variable(b.norm(2), name='b_norm')
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         if self.use_bias:
             W, b = self.params
             self.biases_init.initialize(b, self.rng)
@@ -273,12 +275,14 @@ class Bias(Feedforward, Initializable):
         super(Bias, self).__init__(**kwargs)
         self.dim = dim
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         b = shared_floatx_nans((self.output_dim,), name='b')
         add_role(b, BIAS)
         self.params.append(b)
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         b, = self.params
         self.biases_init.initialize(b, self.rng)
 

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -323,7 +323,8 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
         self.children = [self.state_transformers, attended_transformer,
                          energy_computer]
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.state_transformers.input_dims = self.state_dims
         self.state_transformers.output_dims = [self.match_dim
                                                for name in self.state_names]
@@ -566,7 +567,8 @@ class AttentionRecurrent(AbstractAttentionRecurrent, Initializable):
 
         self.children = [self.transition, self.attention, self.distribute]
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.attention.state_dims = self.transition.get_dims(
             self.attention.state_names)
         self.attention.attended_dim = self.get_dim(self.attended_name)

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -49,7 +49,7 @@ from six import add_metaclass
 
 from blocks.bricks import (MLP, Identity, Brick, Initializable, Sequence,
                            Feedforward, Linear, Tanh)
-from blocks.bricks.base import lazy, application
+from blocks.bricks.base import lazy, application, allocation_push
 from blocks.bricks.parallel import Parallel, Distribute
 from blocks.bricks.recurrent import recurrent, BaseRecurrent
 from blocks.utils import dict_union, dict_subset

--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -105,7 +105,7 @@ class AbstractAttention(Brick):
     attended_dim : int
 
     """
-    @lazy
+    @lazy(allocation=['state_names', 'state_dims', 'attended_dim'])
     def __init__(self, state_names, state_dims, attended_dim, **kwargs):
         self.state_names = state_names
         self.state_dims = state_dims
@@ -303,7 +303,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
        Machine Translation by Jointly Learning to Align and Translate.
 
     """
-    @lazy
+    @lazy(allocation=['match_dim'])
     def __init__(self, match_dim, state_transformer=None,
                  attended_transformer=None, energy_computer=None, **kwargs):
         super(SequenceContentAttention, self).__init__(**kwargs)
@@ -414,7 +414,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
 
 class ShallowEnergyComputer(Sequence, Initializable, Feedforward):
     """A simple energy computer: first tanh, then weighted sum."""
-    @lazy
+    @lazy()
     def __init__(self, **kwargs):
         super(ShallowEnergyComputer, self).__init__(
             [Tanh().apply, MLP([Identity()]).apply], **kwargs)

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -139,11 +139,12 @@ class Application(object):
 
         # Construct the ApplicationCall, used to store data in for this call
         call = ApplicationCall(brick, self)
+        bound_application = getattr(brick, self.name)
         args = list(args)
+        if 'application' in args_names:
+            args.insert(args_names.index('application'), bound_application)
         if 'application_call' in args_names:
             args.insert(args_names.index('application_call'), call)
-        if 'application' in args_names:
-            args.insert(args_names.index('application'), self)
 
         if not brick.allocated:
             brick.allocate()
@@ -187,7 +188,7 @@ class Application(object):
         for i, output in enumerate(outputs):
             if isinstance(output, tensor.Variable):
                 try:
-                    name = self.outputs[i]
+                    name = bound_application.outputs[i]
                 except AttributeError:
                     name = "output_{}".format(i)
                 except IndexError:
@@ -200,7 +201,7 @@ class Application(object):
         if as_list:
             return outputs
         if as_dict:
-            return OrderedDict(equizip(self.outputs, outputs))
+            return OrderedDict(equizip(bound_application.outputs, outputs))
         return unpack(outputs)  # TODO What if output is single element list?
 
     def property(self, name):

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -145,8 +145,6 @@ class Application(object):
 
         if not brick.allocated:
             brick.allocate()
-        if not brick.initialized:
-            brick.initialize()
 
         # Annotate all the input variables which are Theano variables
         def copy_and_tag(variable, role, name):

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -2,33 +2,323 @@ import inspect
 from abc import ABCMeta
 from collections import OrderedDict
 from types import MethodType
+from functools import wraps
 
 import six
-from six import add_metaclass
+from picklable_itertools.extras import equizip
+from six import add_metaclass, create_bound_method
 from theano import tensor
 from theano.gof import Variable
+from toolz import merge
 
 from blocks.graph import add_annotation, Annotation
 from blocks.roles import add_role, PARAMETER, INPUT, OUTPUT
-from blocks.utils import pack, repr_attrs, reraise_as, unpack
+from blocks.utils import pack, unpack, reraise_as
 from blocks.utils.containers import AnnotatingList
 
 
 def create_unbound_method(func, cls):
-    """Create an unbounded method from a function and a class.
-
-    Notes
-    -----
-    See https://bitbucket.org/gutworth/six/pull-request/64.
-
-    """
     if six.PY2:
         return MethodType(func, None, cls)
-    if six.PY3:
-        return func
+    return func
+
+
+class BoundApplication(object):
+    def __init__(self, application, brick):
+        self.application = application
+        self.brick = brick
+
+    def __getattr__(self, attr):
+        if hasattr(self.application, attr):
+            return getattr(self.application, attr)
+        if attr in self.application.properties:
+            return self.application.properties[attr](self.brick)
+        if self.application.delegate_func:
+            return getattr(self.application.delegate_func(self.brick), attr)
+        raise AttributeError(attr)
+
+    def __call__(self, *args, **kwargs):
+        return self.application(*args, **kwargs)
+
+
+class ApplicationCall(Annotation):
+    """A link between the variable tags and bricks.
+
+    The application call can be used to attach to an apply call auxiliary
+    variables (e.g. monitors or regularizers) that do not form part of the
+    main computation graph.
+
+    The application call object is created before the call to the
+    application method and can be accessed by specifying an
+    application_call argument.
+
+    Also see :class:`.Annotation`.
+
+    Parameters
+    ----------
+    brick : :class:`Brick` instance
+        The brick whose application is called
+    application : :class:`BoundApplication` instance
+        The bound application (i.e. belong to a brick instance) object
+        being called
+
+    Examples
+    --------
+    >>> class Foo(Brick):
+    ...     @application()
+    ...     def apply(self, x, application_call):
+    ...         application_call.add_auxiliary_variable(x.mean())
+    ...         return x + 1
+    >>> x = tensor.vector()
+    >>> y = Foo().apply(x)
+    >>> from blocks.filter import get_application_call
+    >>> get_application_call(y) # doctest: +ELLIPSIS
+    <blocks.bricks.base.ApplicationCall object at ...>
+
+    """
+    def __init__(self, brick, application):
+        self.brick = brick
+        self.application = application
+        super(ApplicationCall, self).__init__()
+
+    def add_auxiliary_variable(self, variable, roles=None, name=None):
+        if name:
+            variable.name = _variable_name(
+                self.brick.name, self.application.name, name)
+            variable.tag.name = name
+        add_annotation(variable, self.brick)
+        return super(ApplicationCall, self).add_auxiliary_variable(
+            variable, roles)
 
 # Rename built-in property to avoid conflict with Application.property
 property_ = property
+
+
+class Application(object):
+    call_stack = []
+
+    def __init__(self, *args, **kwargs):
+        self.attributes = kwargs
+        self.properties = {}
+        self.delegate_func = None
+        self.bound_applications = {}
+        if args:
+            self._decorate(args[0])
+            self.decorated = True
+        else:
+            self.decorated = False
+
+    def _decorate(self, func):
+        self.func = func
+        wraps(self.func)(self)
+        for attr, value in self.attributes.items():
+            if hasattr(self, attr):
+                raise ValueError
+            setattr(self, attr, value)
+
+    @property
+    def name(self):
+        return self.func.__name__
+
+    def __call__(self, *args, **kwargs):
+        if not self.decorated:
+            self._decorate(*args)
+            self.decorated = True
+            return self
+        return self._apply(*args, **kwargs)
+
+    def _apply(self, brick, *args, **kwargs):
+        as_dict = kwargs.pop('as_dict', False)
+        as_list = kwargs.pop('as_list', False)
+        if as_list and as_dict:
+            raise ValueError
+
+        # Find the names of the inputs to the application method
+        args_names, varargs_name, _, _ = inspect.getargspec(self.func)
+        args_names = args_names[1:]
+
+        # Construct the ApplicationCall, used to store data in for this call
+        call = ApplicationCall(brick, self)
+        args = list(args)
+        if 'application_call' in args_names:
+            args.insert(args_names.index('application_call'), call)
+
+        if not brick.allocated:
+            brick.allocate()
+        if not brick.initialized:
+            brick.initialize()
+
+        # Annotate all the input variables which are Theano variables
+        def copy_and_tag(variable, role, name):
+            """Helper method to copy a variable and annotate it."""
+            copy = variable.copy()
+            add_annotation(copy, brick)
+            add_annotation(copy, call)
+            add_role(copy, role)
+            # Names
+            copy.tag.name = name
+            copy.name = _variable_name(brick.name, self.name, name)
+            return copy
+
+        for i, input_ in enumerate(args):
+            if isinstance(input_, tensor.Variable):
+                if i < len(args_names):
+                    name = args_names[i]
+                else:
+                    name = "{}_{}".format(varargs_name, i - len(args_names))
+                args[i] = copy_and_tag(input_, INPUT, name)
+        for name, input_ in kwargs.items():
+            if isinstance(input_, tensor.Variable):
+                kwargs[name] = copy_and_tag(input_, INPUT, name)
+
+        # Run the application method on the annotated variables
+        if (self.call_stack and brick is not self.call_stack[-1] and
+                brick not in self.call_stack[-1].children):
+            raise ValueError('{} cannot call non-child {}'.format(
+                self.call_stack[-1], brick))
+        self.call_stack.append(brick)
+        try:
+            outputs = self.func(brick, *args, **kwargs)
+            outputs = pack(outputs)
+        finally:
+            del self.call_stack[:]
+
+        # Rename and annotate output variables
+        for i, output in enumerate(outputs):
+            if isinstance(output, tensor.Variable):
+                try:
+                    name = self.outputs[i]
+                except AttributeError:
+                    name = "output_{}".format(i)
+                except IndexError:
+                    reraise_as(ValueError("unexpected outputs"))
+                # TODO Tag with dimensions, axes, etc. for error-checking
+                outputs[i] = copy_and_tag(outputs[i],
+                                          OUTPUT, name)
+
+        # Return values
+        if as_list:
+            return outputs
+        if as_dict:
+            return OrderedDict(equizip(self.outputs, outputs))
+        return unpack(outputs)  # TODO What if output is single element list?
+
+    def property(self, name):
+        def wrapped_property(property_func):
+            self.properties[name] = property_func
+            return property_func
+        return wrapped_property
+
+    def delegate(self, delegate_func):
+        self.delegate_func = delegate_func
+
+    def __get__(self, instance, cls):
+        if instance is None:
+            return create_unbound_method(self, cls)
+        if instance not in self.bound_applications:
+            bound_application = BoundApplication(self, instance)
+            wraps(self)(bound_application)
+            self.bound_applications[instance] = create_bound_method(
+                bound_application, instance)
+        return self.bound_applications[instance]
+
+    @property_
+    def inputs(self):
+        return self._inputs
+
+    @inputs.setter
+    def inputs(self, inputs):
+        args_names, varargs_name, _, _ = inspect.getargspec(self.func)
+        if not all(input_ in args_names + [varargs_name] for input_ in inputs):
+            raise ValueError("application input is not an argument")
+        self._inputs = inputs
+
+
+application = Application
+
+
+def args_to_kwargs(args, f):
+    arg_names, vararg_names, _, _ = inspect.getargspec(f)
+    return dict((arg_name, arg) for arg_name, arg
+                in zip(arg_names + [vararg_names], args))
+
+
+NoneAllocation = object()
+NoneInitialization = object()
+
+
+def lazy(allocation=None, initialization=None):
+    if not allocation:
+        allocation = []
+    if not initialization:
+        initialization = []
+
+    def lazy_wrapper(init):
+        def lazy_init(*args, **kwargs):
+            self = args[0]
+            self.allocation_args = allocation
+            self.initialization_args = initialization
+            kwargs = merge(args_to_kwargs(args, init), kwargs)
+            for allocation_arg in allocation:
+                kwargs.setdefault(allocation_arg, NoneAllocation)
+            for initialization_arg in initialization:
+                kwargs.setdefault(initialization_arg, NoneInitialization)
+            return init(**kwargs)
+        wraps(init)(lazy_init)
+        return lazy_init
+    return lazy_wrapper
+
+
+def allocation(allocate):
+    def wrapped_allocate(self):
+        if any(getattr(self, arg) is NoneAllocation
+               for arg in self.allocation_args):
+            raise ValueError('allocation config not set')
+        if not self.allocation_config_pushed:
+            self.push_allocation_config()
+        for child in self.children:
+            child.allocate()
+        self.parameters = []
+        allocate(self)
+        self.allocated = True
+    wraps(allocate)(wrapped_allocate)
+    return wrapped_allocate
+
+
+def initialization(initialize):
+    def wrapped_initialize(self):
+        if any(getattr(self, arg) is NoneInitialization
+               for arg in self.initialization_args):
+            raise ValueError('initialization config not set')
+        if not self.allocated:
+            self.allocate()
+        if not self.initialization_config_pushed:
+            self.push_initialization_config()
+        for child in self.children:
+            child.initialize()
+        initialize(self)
+        self.initialized = True
+    wraps(initialize)(wrapped_initialize)
+    return wrapped_initialize
+
+
+def push_decorator_factory(stage):
+    def push_decorator(push_config):
+        def wrapped_push_config(self):
+            push_config(self)
+            setattr(self, '{}_config_pushed'.format(stage), True)
+            for child in self.children:
+                try:
+                    getattr(child, 'push_{}_config'.format(stage))()
+                except Exception:
+                    setattr(self, '{}_config_pushed'.format(stage), False)
+                    raise
+        wraps(push_config)(wrapped_push_config)
+        return wrapped_push_config
+    return push_decorator
+
+allocation_push = push_decorator_factory('allocation')
+initialization_push = push_decorator_factory('initialization')
 
 
 class Parameters(AnnotatingList):
@@ -59,492 +349,8 @@ class Children(AnnotatingList):
             child.parents.remove(self.brick)
 
 
-class Application(object):
-    """An application method belonging to a particular type of brick.
-
-    The application methods of each :class:`Brick` class are automatically
-    replaced by an instance of :class:`Application`. This allows us to
-    store metadata about particular application methods (such as their in-
-    and outputs) easily.
-
-    Attributes
-    ----------
-    application : callable
-        The original (unbounded) application function defined on the
-        :class:`Brick`.
-    delegate_function : callable
-        A function that takes a :class:`Brick` instance as an argument and
-        returns a :class:`BoundApplication` object to which attribute
-        requests should be routed.
-    properties : :obj:`dict` (:obj:`str`, :obj:`callable`)
-        A dictionary of property getters that should be called when an
-        attribute with the given name is requested.
-    instances : :obj:`dict` (:class:`Brick`, :class:`BoundApplication`)
-        A record of bound application instances created by the descriptor
-        protocol.
-    call_stack : :obj:`list` of :class:`Brick`
-        The call stack of brick application methods. Used to check whether
-        the current call was made by a parent brick.
-    brick : type
-        The brick class to which this instance belongs.
-
-    Raises
-    ------
-    ValueError
-        If a brick's application method is applied by another brick which
-        does not list the former as a child.
-    ValueError
-        If the application method's inputs and/or outputs don't match with
-        the function signature or the values returned (respectively).
-
-    Notes
-    -----
-    When a :class:`Brick` is instantiated and its application method (i.e.
-    an instance of this class) requested, the descriptor protocol (through
-    the :meth:`__get__` method) automatically instantiates a
-    :class:`BoundApplication` class and returns this. This bound
-    application class can be used to store application information
-    particular to a brick instance. Any attributes unknown to the bounded
-    application are automatically routed to the application that
-    instantiated it.
-
-    """
-    call_stack = []
-
-    def __init__(self, application_function):
-        self._application_function = application_function
-        self.application_name = application_function.__name__
-        self.delegate_function = None
-        self.properties = {}
-
-    @property
-    def application_function(self):
-        if hasattr(self, '_application_function'):
-            return self._application_function
-        return getattr(self.brick, '_' + self.application_name)
-
-    def property(self, name):
-        """Decorator to make application properties.
-
-        Parameters
-        ----------
-        name : str
-            The name the property should take.
-
-        Examples
-        --------
-        >>> class Foo(Brick):
-        ...     @application
-        ...     def apply(self, x):
-        ...         return x + 1
-        ...
-        ...     @apply.property('inputs')
-        ...     def apply_inputs(self):
-        ...         return ['foo', 'bar']
-        >>> foo = Foo()
-        >>> foo.apply.inputs
-        ['foo', 'bar']
-
-        """
-        if not isinstance(name, six.string_types):
-            raise ValueError
-
-        def wrap_property(application_property):
-            self.properties[name] = application_property.__name__
-            return application_property
-        return wrap_property
-
-    def delegate(self, f):
-        """Decorator to assign a delegate application.
-
-        An application method can assign a delegate application. Whenever
-        an attribute is not available, it will be requested from the
-        delegate instead.
-
-        Examples
-        --------
-        >>> class Foo(Brick):
-        ...     @application(outputs=['baz'])
-        ...     def apply(self, x):
-        ...         return x + 1
-        ...
-        ...     @apply.property('inputs')
-        ...     def apply_inputs(self):
-        ...         return ['foo', 'bar']
-        >>> class Bar(Brick):
-        ...     def __init__(self, foo):
-        ...         self.foo = foo
-        ...
-        ...     @application(outputs=['foo'])
-        ...     def apply(self, x):
-        ...         return x + 1
-        ...
-        ...     @apply.delegate
-        ...     def apply_delegate(self):
-        ...         return self.foo.apply
-        >>> foo = Foo()
-        >>> bar = Bar(foo)
-        >>> bar.apply.outputs
-        ['foo']
-        >>> bar.apply.inputs
-        ['foo', 'bar']
-
-        """
-        self.delegate_function = f.__name__
-        return f
-
-    def __get__(self, instance, owner):
-        """Instantiate :class:`BoundApplication` for each :class:`Brick`."""
-        if instance is None:
-            return self
-        if not hasattr(instance, "_bound_applications"):
-            instance._bound_applications = {}
-        key = "{}.{}".format(self.brick.__name__, self.application_name)
-        return instance._bound_applications.setdefault(
-            key, BoundApplication(self, instance))
-
-    def __getattr__(self, name):
-        # Mimic behavior of properties
-        if 'properties' in self.__dict__ and name in self.properties:
-            return property(create_unbound_method(
-                getattr(self, self.properties[name]), self.brick))
-        raise AttributeError
-
-    def __setattr__(self, name, value):
-        # Mimic behavior of read-only properties
-        if 'properties' in self.__dict__ and name in self.properties:
-            raise AttributeError("can't set attribute")
-        super(Application, self).__setattr__(name, value)
-
-    @property_
-    def inputs(self):
-        return self._inputs
-
-    @inputs.setter
-    def inputs(self, inputs):
-        args_names, varargs_name, _, _ = inspect.getargspec(
-            self.application_function)
-        if not all(input_ in args_names + [varargs_name] for input_ in inputs):
-            raise ValueError("Unexpected inputs")
-        self._inputs = inputs
-
-    @property_
-    def name(self):
-        return self.application_name
-
-    def __call__(self, brick, *args, **kwargs):
-        if not isinstance(brick, Brick) and six.PY2:
-            raise TypeError
-        bound_application = self.__get__(brick, brick.__class__)
-        return self.apply(bound_application, *args, **kwargs)
-
-    def apply(self, bound_application, *args, **kwargs):
-        as_dict = kwargs.pop('as_dict', False)
-        as_list = kwargs.pop('as_list', False)
-        if as_list and as_dict:
-            raise ValueError
-
-        brick = bound_application.brick
-
-        # Find the names of the inputs to the application method
-        args_names, varargs_name, _, _ = inspect.getargspec(
-            self.application_function)
-        args_names = args_names[1:]
-
-        # Construct the ApplicationCall, used to store data in for this call
-        call = ApplicationCall(brick, bound_application)
-        args = list(args)
-        if 'application' in args_names:
-            args.insert(args_names.index('application'), bound_application)
-        if 'application_call' in args_names:
-            args.insert(args_names.index('application_call'), call)
-
-        # Allocate before applying, and optionally initialize
-        if not brick.allocated:
-            brick.allocate()
-        if not brick.initialized and not brick.lazy:
-            brick.initialize()
-
-        # Annotate all the input variables which are Theano variables
-        def copy_and_tag(variable, role, name):
-            """Helper method to copy a variable and annotate it."""
-            copy = variable.copy()
-            # Theano name
-            copy.name = _variable_name(brick.name, self.name, name)
-            add_annotation(copy, brick)
-            add_annotation(copy, call)
-            # Blocks name
-            copy.tag.name = name
-            add_role(copy, role)
-            return copy
-
-        for i, input_ in enumerate(args):
-            if isinstance(input_, tensor.Variable):
-                if i < len(args_names):
-                    name = args_names[i]
-                else:
-                    name = "{}_{}".format(varargs_name, i - len(args_names))
-                args[i] = copy_and_tag(input_, INPUT, name)
-        for name, input_ in kwargs.items():
-            if isinstance(input_, tensor.Variable):
-                kwargs[name] = copy_and_tag(input_, INPUT, name)
-
-        # Run the application method on the annotated variables
-        if self.call_stack and brick is not self.call_stack[-1] and \
-                brick not in self.call_stack[-1].children:
-            raise ValueError('Brick ' + str(self.call_stack[-1]) + ' tries '
-                             'to call brick ' + str(self.brick) + ' which '
-                             'is not in the list of its children.')
-        self.call_stack.append(brick)
-        try:
-            outputs = self.application_function(brick, *args, **kwargs)
-            outputs = pack(outputs)
-        finally:
-            self.call_stack.pop()
-
-        # Rename and annotate output variables
-        for i, output in enumerate(outputs):
-            if isinstance(output, tensor.Variable):
-                try:
-                    name = bound_application.outputs[i]
-                except AttributeError:
-                    name = "output_{}".format(i)
-                except IndexError:
-                    reraise_as(ValueError("Unexpected outputs"))
-                # TODO Tag with dimensions, axes, etc. for error-checking
-                outputs[i] = copy_and_tag(outputs[i],
-                                          OUTPUT, name)
-
-        # Return values
-        if as_list:
-            return outputs
-        if as_dict:
-            return OrderedDict(zip(bound_application.outputs, outputs))
-        return unpack(outputs)
-
-
-class BoundApplication(object):
-    """An application method bound to a :class:`Brick` instance."""
-    def __init__(self, application, brick):
-        self.application = application
-        self.brick = brick
-
-    def __getattr__(self, name):
-        # Prevent infinite loops
-        if name == 'application':
-            raise AttributeError
-        # These always belong to the parent (the unbound application)
-        if name in ('delegate_function', 'properties'):
-            return getattr(self.application, name)
-        if name in self.properties.values():
-            return getattr(self.application.brick, name)
-        if name in self.properties:
-            return getattr(self, self.properties[name])(self.brick)
-        # First try the parent (i.e. class level), before trying the delegate
-        try:
-            return getattr(self.application, name)
-        except AttributeError:
-            if self.delegate_function:
-                return getattr(getattr(self.brick,
-                                       self.delegate_function)(),
-                               name)
-            raise
-
-    @property
-    def name(self):
-        return self.application.name
-
-    def __call__(self, *args, **kwargs):
-        return self.application.apply(self, *args, **kwargs)
-
-
-def rename_function(function, new_name):
-    old_name = function.__name__
-    function.__name__ = new_name
-    if six.PY3:
-        function.__qualname__ = \
-            function.__qualname__[:-len(old_name)] + new_name
-    return function
-
-
-class _Brick(ABCMeta):
-    """Metaclass which attaches brick instances to the applications."""
-    def __new__(mcs, name, bases, namespace):
-        for attr in list(namespace.values()):
-            if (isinstance(attr, Application) and
-                    hasattr(attr, '_application_function')):
-                namespace['_' + attr.application_name] = \
-                    rename_function(attr._application_function,
-                                    '_' + attr.application_name)
-                del attr._application_function
-        brick = super(_Brick, mcs).__new__(mcs, name, bases, namespace)
-        for attr in namespace.values():
-            if isinstance(attr, Application):
-                attr.brick = brick
-        return brick
-
-
-@add_metaclass(_Brick)
+@add_metaclass(ABCMeta)
 class Brick(Annotation):
-    """A brick encapsulates Theano operations with parameters.
-
-    A brick goes through the following stages:
-
-    1. Construction: The call to :meth:`__init__` constructs a
-       :class:`Brick` instance with a name and creates any child bricks as
-       well.
-    2. Allocation of parameters:
-
-       a) Allocation configuration of children: The
-          :meth:`push_allocation_config` method configures any children of
-          this block.
-       b) Allocation: The :meth:`allocate` method allocates the shared
-          Theano variables required for the parameters. Also allocates
-          parameters for all children.
-
-    3. The following can be done in either order:
-
-       a) Application: By applying the brick to a set of Theano
-          variables a part of the computational graph of the final model is
-          constructed.
-       b) The initialization of parameters:
-
-          1. Initialization configuration of children: The
-             :meth:`push_initialization_config` method configures any
-             children of this block.
-          2. Initialization: This sets the initial values of the
-             parameters by a call to :meth:`initialize`, which is needed
-             to call the final compiled Theano function.  Also initializes
-             all children.
-
-    Not all stages need to be called explicitly. Step 3(a) will
-    automatically allocate the parameters if needed. Similarly, step
-    3(b.2) and 2(b) will automatically perform steps 3(b.1) and 2(a) if
-    needed. They only need to be called separately if greater control is
-    required. The only two methods which always need to be called are an
-    application method to construct the computational graph, and the
-    :meth:`initialize` method in order to initialize the parameters.
-
-    At each different stage, a brick might need a certain set of
-    configuration settings. All of these settings can be passed to the
-    :meth:`__init__` constructor. However, by default many bricks support
-    *lazy initialization*. This means that the configuration settings can
-    be set later.
-
-    .. note::
-
-       Some arguments to :meth:`__init__` are *always* required, even when
-       lazy initialization is enabled. Other arguments must be given before
-       calling :meth:`allocate`, while others yet only need to be given in
-       order to call :meth:`initialize`. Always read the documentation of
-       each brick carefully.
-
-    Lazy initialization can be turned off by setting ``Brick.lazy =
-    False``. In this case, there is no need to call :meth:`initialize`
-    manually anymore, but all the configuration must be passed to the
-    :meth:`__init__` method.
-
-    Parameters
-    ----------
-    name : str, optional
-        The name of this brick. This can be used to filter the application
-        of certain modifications by brick names. By default, the brick
-        receives the name of its class (lowercased).
-
-    Attributes
-    ----------
-    name : str
-        The name of this brick.
-    lazy : bool
-        ``True`` by default. When bricks are lazy, not all configuration
-        needs to be provided to the constructor, allowing it to be set in
-        another way after construction. Many parts of the library rely on
-        this behavior. However, it does require a separate call to
-        :meth:`initialize`. If set to ``False`` on the other hand, bricks
-        will be ready to run after construction.
-    print_shapes : bool
-        ``False`` by default. If ``True`` it logs the shapes of all the
-        input and output variables, which can be useful for debugging.
-    params : list of :class:`~tensor.TensorSharedVariable` and ``None``
-        After calling the :meth:`allocate` method this attribute will be
-        populated with the shared variables storing this brick's
-        parameters. Allows for ``None`` so that parameters can always be
-        accessed at the same index, even if some parameters are only
-        defined given a particular configuration.
-    children : list of bricks
-        The children of this brick.
-    allocated : bool
-        ``False`` if :meth:`allocate` has not been called yet. ``True``
-        otherwise.
-    initialized : bool
-        ``False`` if :meth:`allocate` has not been called yet. ``True``
-        otherwise.
-    allocation_config_pushed : bool
-        ``False`` if :meth:`allocate` or :meth:`push_allocation_config`
-        hasn't been called yet. ``True`` otherwise.
-    initialization_config_pushed : bool
-        ``False`` if :meth:`initialize` or
-        :meth:`push_initialization_config` hasn't been called yet. ``True``
-        otherwise.
-
-    Notes
-    -----
-    To provide support for lazy initialization, apply the :meth:`lazy`
-    decorator to the :meth:`__init__` method.
-
-    Brick implementations *must* call the :meth:`__init__` constructor of
-    their parent using `super(BlockImplementation,
-    self).__init__(**kwargs)` at the *beginning* of the overriding
-    `__init__`.
-
-    The methods :meth:`_allocate` and :meth:`_initialize` need to be
-    overridden if the brick needs to allocate shared variables and
-    initialize their values in order to function.
-
-    A brick can have any number of methods which apply the brick on Theano
-    variables. These methods should be decorated with the
-    :func:`application` decorator.
-
-    If a brick has children, they must be listed in the :attr:`children`
-    attribute. Moreover, if the brick wants to control the configuration of
-    its children, the :meth:`_push_allocation_config` and
-    :meth:`_push_initialization_config` methods need to be overridden.
-
-    Examples
-    --------
-    By default, bricks have lazy initialization enabled.
-
-    >>> import theano
-    >>> from blocks.initialization import IsotropicGaussian, Constant
-    >>> from blocks.bricks import Linear
-    >>> linear = Linear(input_dim=5, output_dim=3,
-    ...                 weights_init=IsotropicGaussian(),
-    ...                 biases_init=Constant(0))
-    >>> x = theano.tensor.vector()
-    >>> linear.apply(x)  # Calls linear.allocate() automatically
-    linear_apply_output
-    >>> linear.initialize()  # Initializes the weight matrix
-
-    In simple cases, eager bricks are easier to deal with.
-
-    >>> from blocks.initialization import IsotropicGaussian, Constant
-    >>> Brick.lazy = False
-    >>> linear = Linear(5, 3, weights_init=IsotropicGaussian(),
-    ...                 biases_init=Constant(0))
-    >>> linear.apply(x)
-    linear_apply_output
-
-    .. doctest::
-       :hide:
-
-       >>> Brick.lazy = True  # Reset for other doctests
-
-    """
-    #: See :attr:`Brick.lazy`
-    lazy = True
-    #: See :attr:`Brick.print_shapes`
-    print_shapes = False
-
     def __init__(self, name=None):
         if name is None:
             name = self.__class__.__name__.lower()
@@ -553,22 +359,38 @@ class Brick(Annotation):
         self.children = []
         self.parents = []
 
+        self.allocation_args = []
+        self.initialization_args = []
+
         self.allocated = False
         self.allocation_config_pushed = False
         self.initialized = False
         self.initialization_config_pushed = False
         super(Brick, self).__init__()
 
-    def __repr__(self):
-        return repr_attrs(self, 'name')
+    @allocation
+    def allocate(self):
+        pass
+
+    @initialization
+    def initialize(self):
+        pass
+
+    @allocation_push
+    def push_allocation_config(self):
+        pass
+
+    @initialization_push
+    def push_initialization_config(self):
+        pass
 
     @property
-    def params(self):
-        return self._params
+    def parameters(self):
+        return self._parameters
 
-    @params.setter
-    def params(self, value):
-        self._params = Parameters(self, value)
+    @parameters.setter
+    def parameters(self, value):
+        self._parameters = Parameters(self, value)
 
     @property
     def children(self):
@@ -577,165 +399,6 @@ class Brick(Annotation):
     @children.setter
     def children(self, value):
         self._children = Children(self, value)
-
-    def allocate(self):
-        """Allocate shared variables for parameters.
-
-        Based on the current configuration of this :class:`Brick` create
-        Theano shared variables to store the parameters.  After allocation,
-        parameters are accessible through the :attr:`params` attribute.
-
-        This method calls the :meth:`allocate` method of all children
-        first, allowing the :meth:`_allocate` method to override the
-        parameters of the children if needed.
-
-        Raises
-        ------
-        ValueError
-            If the configuration of this brick is insufficient to determine
-            the number of parameters or their dimensionality to be
-            initialized.
-
-        Notes
-        -----
-        This method sets the :attr:`params` attribute to an empty list.
-        This is in order to ensure that calls to this method completely
-        reset the parameters.
-
-        """
-        if not self.allocation_config_pushed:
-            self.push_allocation_config()
-        for child in self.children:
-            child.allocate()
-        self.params = []
-        try:
-            self._allocate()
-        except Exception:
-            if self.lazy:
-                reraise_as("Lazy initialization is enabled, so please make "
-                           "sure you have set all the required configuration "
-                           "for this method call.")
-            else:
-                raise
-        self.allocated = True
-
-    def _allocate(self):
-        """Brick implementation of parameter initialization.
-
-        Implement this if your brick needs to allocate its parameters.
-
-        .. warning::
-
-           This method should never be called directly. Call
-           :meth:`initialize` instead.
-
-        """
-        pass
-
-    def initialize(self):
-        """Initialize parameters.
-
-        Intialize parameters, such as weight matrices and biases.
-
-        Notes
-        -----
-        If the brick has not allocated its parameters yet, this method will
-        call the :meth:`allocate` method in order to do so.
-
-        """
-        if not self.allocated:
-            self.allocate()
-        if not self.initialization_config_pushed:
-            self.push_initialization_config()
-        for child in self.children:
-            child.initialize()
-        try:
-            self._initialize()
-        except Exception:
-            if self.lazy:
-                reraise_as("Lazy initialization is enabled, so please make "
-                           "sure you have set all the required configuration "
-                           "for this method call.")
-            else:
-                raise
-        self.initialized = True
-
-    def _initialize(self):
-        """Brick implementation of parameter initialization.
-
-        Implement this if your brick needs to initialize its parameters.
-
-        .. warning::
-
-           This method should never be called directly. Call
-           :meth:`initialize` instead.
-
-        """
-        pass
-
-    def push_allocation_config(self):
-        """Push the configuration for allocation to child bricks.
-
-        Bricks can configure their children, based on their own current
-        configuration. This will be automatically done by a call to
-        :meth:`allocate`, but if you want to override the configuration of
-        child bricks manually, then you can call this function manually.
-
-        """
-        self._push_allocation_config()
-        self.allocation_config_pushed = True
-        for child in self.children:
-            try:
-                child.push_allocation_config()
-            except Exception:
-                self.allocation_config_pushed = False
-                raise
-
-    def _push_allocation_config(self):
-        """Brick implementation of configuring child before allocation.
-
-        Implement this if your brick needs to set the configuration of its
-        children before allocation.
-
-        .. warning::
-
-           This method should never be called directly. Call
-           :meth:`push_allocation_config` instead.
-
-        """
-        pass
-
-    def push_initialization_config(self):
-        """Push the configuration for initialization to child bricks.
-
-        Bricks can configure their children, based on their own current
-        configuration. This will be automatically done by a call to
-        :meth:`initialize`, but if you want to override the configuration
-        of child bricks manually, then you can call this function manually.
-
-        """
-        self._push_initialization_config()
-        self.initialization_config_pushed = True
-        for child in self.children:
-            try:
-                child.push_initialization_config()
-            except Exception:
-                self.initialization_config_pushed = False
-                raise
-
-    def _push_initialization_config(self):
-        """Brick implementation of configuring child before initialization.
-
-        Implement this if your brick needs to set the configuration of its
-        children before initialization.
-
-        .. warning::
-
-           This method should never be called directly. Call
-           :meth:`push_initialization_config` instead.
-
-        """
-        pass
 
     def get_dim(self, name):
         """Get dimension of an input/output variable of a brick.
@@ -746,8 +409,7 @@ class Brick(Annotation):
             The name of the variable.
 
         """
-        raise ValueError("No dimension information for {} available"
-                         .format(name))
+        raise ValueError("no dimension information for {}".format(name))
 
     def get_dims(self, names):
         """Get list of dimensions for a set of input/output variables.
@@ -764,170 +426,6 @@ class Brick(Annotation):
 
         """
         return [self.get_dim(name) for name in names]
-
-
-def lazy(func):
-    """Makes the initialization lazy.
-
-    Any positional argument not given will be set to ``None``. Positional
-    arguments can also be given as keyword arguments.
-
-    Parameters
-    ----------
-    func : method
-        The __init__ method to make lazy.
-
-    Examples
-    --------
-    >>> class SomeBrick(Brick):
-    ...     @lazy
-    ...     def __init__(self, a, b, c='c', d=None):
-    ...         print(a, b, c, d)
-    >>> brick = SomeBrick('a')
-    a None c None
-    >>> brick = SomeBrick(d='d', b='b')
-    None b c d
-    >>> Brick.lazy = False
-    >>> brick = SomeBrick('a')
-    Traceback (most recent call last):
-      ...
-    TypeError: __init__() missing 1 required positional argument: 'b'
-
-    .. doctest::
-       :hide:
-
-       >>> Brick.lazy = True  # Reset for other doctests
-
-    """
-    arg_spec = inspect.getargspec(func)
-    arg_names = arg_spec.args[1:]
-    defaults = arg_spec.defaults
-    if defaults is None:
-        defaults = []
-
-    def init(self, *args, **kwargs):
-        if not self.lazy:
-            return func(self, *args, **kwargs)
-        # Fill any missing positional arguments with None
-        args = args + (None,) * (len(arg_names) - len(defaults) -
-                                 len(args))
-
-        # Check if positional arguments were passed as keyword arguments
-        args = list(args)
-        for i, arg_name in enumerate(arg_names[:len(arg_names) -
-                                               len(defaults)]):
-            if arg_name in kwargs:
-                if args[i] is not None:
-                    raise ValueError
-                args[i] = kwargs.pop(arg_name)
-
-        return func(self, *args, **kwargs)
-    return init
-
-
-class ApplicationCall(Annotation):
-    """A link between the variable tags and bricks.
-
-    The application call can be used to attach to an apply call auxiliary
-    variables (e.g. monitors or regularizers) that do not form part of the
-    main computation graph.
-
-    The application call object is created before the call to the
-    application method and can be accessed by specifying an
-    application_call argument.
-
-    Also see :class:`.Annotation`.
-
-    Parameters
-    ----------
-    brick : :class:`Brick` instance
-        The brick whose application is called
-    application : :class:`BoundApplication` instance
-        The bound application (i.e. belong to a brick instance) object
-        being called
-
-    Examples
-    --------
-    >>> class Foo(Brick):
-    ...     @application
-    ...     def apply(self, x, application_call):
-    ...         application_call.add_auxiliary_variable(x.mean())
-    ...         return x + 1
-    >>> x = tensor.vector()
-    >>> y = Foo().apply(x)
-    >>> from blocks.filter import get_application_call
-    >>> get_application_call(y) # doctest: +ELLIPSIS
-    <blocks.bricks.base.ApplicationCall object at ...>
-
-    """
-    def __init__(self, brick, application):
-        self.brick = brick
-        self.application = application
-        super(ApplicationCall, self).__init__()
-
-    def add_auxiliary_variable(self, variable, roles=None, name=None):
-        if name:
-            variable.name = _variable_name(
-                self.brick.name, self.application.name, name)
-            variable.tag.name = name
-            name = None
-        add_annotation(variable, self.brick)
-        return super(ApplicationCall, self).add_auxiliary_variable(
-            variable, roles, name)
-
-
-def application(*args, **kwargs):
-    r"""Decorator for methods that apply a brick to inputs.
-
-    Parameters
-    ----------
-    \*args, optional
-        The application method to wrap.
-    \*\*kwargs, optional
-        Attributes to attach to this application.
-
-    Notes
-    -----
-    This decorator replaces application methods with :class:`Application`
-    instances. It also sets the attributes given as keyword arguments to
-    the decorator.
-
-    Note that this decorator purposely does not wrap the original method
-    using e.g. :func:`~functools.wraps` or
-    :func:`~functools.update_wrapper`, since that would make the class
-    impossible to pickle (see notes at :class:`Application`).
-
-    Examples
-    --------
-    >>> class Foo(Brick):
-    ...     @application(inputs=['x'], outputs=['y'])
-    ...     def apply(self, x):
-    ...         return x + 1
-    ...     @application
-    ...     def other_apply(self, x):
-    ...         return x - 1
-    >>> foo = Foo()
-    >>> Foo.apply.inputs
-    ['x']
-    >>> foo.apply.outputs
-    ['y']
-    >>> Foo.other_apply # doctest: +ELLIPSIS
-    <blocks.bricks.base.Application object at ...>
-
-    """
-    if not ((args and not kwargs) or (not args and kwargs)):
-        raise ValueError
-    if args:
-        application_function, = args
-        application = Application(application_function)
-        return application
-    else:
-        def wrap_application(application_function):
-            application = Application(application_function)
-            for key, value in kwargs.items():
-                setattr(application, key, value)
-            return application
-        return wrap_application
 
 
 def _variable_name(brick_name, application_name, name):

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -142,6 +142,8 @@ class Application(object):
         args = list(args)
         if 'application_call' in args_names:
             args.insert(args_names.index('application_call'), call)
+        if 'application' in args_names:
+            args.insert(args_names.index('application'), self)
 
         if not brick.allocated:
             brick.allocate()

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -243,8 +243,20 @@ def args_to_kwargs(args, f):
                 in zip(arg_names + [vararg_names], args))
 
 
-NoneAllocation = object()
-NoneInitialization = object()
+class LazyNone(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+    def __bool__(self):
+        return False
+
+    __nonzero__ = __bool__
+
+NoneAllocation = LazyNone('NoneAllocation')
+NoneInitialization = LazyNone('NoneInitialization')
 
 
 def lazy(allocation=None, initialization=None):

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -2,7 +2,8 @@ from theano.tensor.nnet.conv import conv2d, ConvOp
 from theano.tensor.signal.downsample import max_pool_2d, DownsampleFactorMax
 
 from blocks.bricks import Initializable, Feedforward, Sequence
-from blocks.bricks.base import application, Brick, lazy
+from blocks.bricks.base import (application, Brick, lazy, allocation,
+                                initialization, allocation_push)
 from blocks.roles import add_role, FILTER, BIAS
 from blocks.utils import shared_floatx_nans
 

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -210,7 +210,8 @@ class ConvolutionalActivation(Sequence, Initializable):
             application_methods=[self.convolution.apply, activation],
             **kwargs)
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         for attr in ['filter_size', 'num_filters', 'step', 'border_mode',
                      'batch_size', 'num_channels', 'image_size']:
             setattr(self.convolution, attr, getattr(self, attr))
@@ -266,7 +267,8 @@ class ConvolutionalLayer(Sequence, Initializable):
         self.border_mode = border_mode
         self.image_size = image_size
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         for attr in ['filter_size', 'num_filters', 'num_channels',
                      'batch_size', 'border_mode', 'image_size']:
             setattr(self.convolution, attr, getattr(self, attr))
@@ -339,7 +341,8 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
             return self.layers[-1].get_dim(name)
         return super(ConvolutionalSequence, self).get_dim(name)
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         num_channels = self.num_channels
         image_size = self.image_size
         for layer in self.layers:

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -38,7 +38,7 @@ class Convolutional(Initializable):
         details. Defaults to 'valid'.
 
     """
-    @lazy
+    @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])
     def __init__(self, filter_size, num_filters, num_channels, batch_size=None,
                  image_size=None, step=(1, 1), border_mode='valid', **kwargs):
         super(Convolutional, self).__init__(**kwargs)
@@ -137,7 +137,7 @@ class MaxPooling(Initializable, Feedforward):
         two dimensions will be used to calculate the output dimension.
 
     """
-    @lazy
+    @lazy(allocation=['pooling_size'])
     def __init__(self, pooling_size, step=None, input_dim=None, **kwargs):
         super(MaxPooling, self).__init__(**kwargs)
 
@@ -190,7 +190,7 @@ class ConvolutionalActivation(Sequence, Initializable):
     :class:`Convolutional` for the other parameters.
 
     """
-    @lazy
+    @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])
     def __init__(self, activation, filter_size, num_filters, num_channels,
                  batch_size=None, image_size=None, step=(1, 1),
                  border_mode='valid', **kwargs):
@@ -241,7 +241,7 @@ class ConvolutionalLayer(Sequence, Initializable):
     Uses max pooling.
 
     """
-    @lazy
+    @lazy(allocation=['filter_size', 'num_filters'])
     def __init__(self, activation, filter_size, num_filters, pooling_size,
                  num_channels, conv_step=(1, 1), pooling_step=None,
                  batch_size=None, image_size=None, border_mode='valid',
@@ -318,7 +318,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
     layer by the :meth:`~.Brick.push_allocation_config` method.
 
     """
-    @lazy
+    @lazy(allocation=['num_channels'])
     def __init__(self, layers, num_channels, batch_size=None, image_size=None,
                  **kwargs):
         self.layers = layers

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -245,7 +245,8 @@ class ConvolutionalLayer(Sequence, Initializable):
     Uses max pooling.
 
     """
-    @lazy(allocation=['filter_size', 'num_filters'])
+    @lazy(allocation=['filter_size', 'num_filters', 'pooling_size',
+                      'num_channels'])
     def __init__(self, activation, filter_size, num_filters, pooling_size,
                  num_channels, conv_step=(1, 1), pooling_step=None,
                  batch_size=None, image_size=None, border_mode='valid',

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -51,7 +51,8 @@ class Convolutional(Initializable):
         self.step = step
         self.border_mode = border_mode
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         W = shared_floatx_nans((self.num_filters, self.num_channels) +
                                self.filter_size, name='W')
         add_role(W, FILTER)
@@ -63,7 +64,8 @@ class Convolutional(Initializable):
             self.params.append(b)
             self.add_auxiliary_variable(b.norm(2), name='b_norm')
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         if self.use_bias:
             W, b = self.params
             self.biases_init.initialize(b, self.rng)

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -57,21 +57,21 @@ class Convolutional(Initializable):
         W = shared_floatx_nans((self.num_filters, self.num_channels) +
                                self.filter_size, name='W')
         add_role(W, FILTER)
-        self.params.append(W)
+        self.parameters.append(W)
         self.add_auxiliary_variable(W.norm(2), name='W_norm')
         if self.use_bias:
             b = shared_floatx_nans(self.get_dim('output'), name='b')
             add_role(b, BIAS)
-            self.params.append(b)
+            self.parameters.append(b)
             self.add_auxiliary_variable(b.norm(2), name='b_norm')
 
     @initialization
     def initialize(self):
         if self.use_bias:
-            W, b = self.params
+            W, b = self.parameters
             self.biases_init.initialize(b, self.rng)
         else:
-            W, = self.params
+            W, = self.parameters
         self.weights_init.initialize(W, self.rng)
 
     @application(inputs=['input_'], outputs=['output'])
@@ -97,9 +97,9 @@ class Convolutional(Initializable):
 
         """
         if self.use_bias:
-            W, b = self.params
+            W, b = self.parameters
         else:
-            W, = self.params
+            W, = self.parameters
 
         output = conv2d(
             input_, W,

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -274,7 +274,7 @@ class ConvolutionalLayer(Sequence, Initializable):
                      'batch_size', 'border_mode', 'image_size']:
             setattr(self.convolution, attr, getattr(self, attr))
         self.convolution.step = self.conv_step
-        self.convolution._push_allocation_config()
+        self.convolution.push_allocation_config()
         if self.image_size is not None:
             pooling_input_dim = self.convolution.get_dim('output')
         else:
@@ -352,7 +352,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
             layer.batch_size = self.batch_size
 
             # Push input dimensions to children
-            layer._push_allocation_config()
+            layer.push_allocation_config()
 
             # Retrieve output dimensions
             # and set it for next layer

--- a/blocks/bricks/lookup.py
+++ b/blocks/bricks/lookup.py
@@ -22,7 +22,7 @@ class LookupTable(Initializable):
     """
     has_bias = False
 
-    @lazy
+    @lazy(allocation=['length', 'dim'])
     def __init__(self, length, dim, **kwargs):
         super(LookupTable, self).__init__(**kwargs)
         self.length = length

--- a/blocks/bricks/lookup.py
+++ b/blocks/bricks/lookup.py
@@ -1,6 +1,6 @@
 """Introduces Lookup brick."""
 from blocks.bricks import Initializable
-from blocks.bricks.base import application, lazy
+from blocks.bricks.base import application, lazy, allocation, initialization
 from blocks.utils import check_theano_variable, shared_floatx_nans
 
 

--- a/blocks/bricks/lookup.py
+++ b/blocks/bricks/lookup.py
@@ -32,11 +32,13 @@ class LookupTable(Initializable):
     def W(self):
         return self.params[0]
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         self.params.append(shared_floatx_nans((self.length, self.dim),
                            name='W'))
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         self.weights_init.initialize(self.W, self.rng)
 
     @application

--- a/blocks/bricks/lookup.py
+++ b/blocks/bricks/lookup.py
@@ -30,12 +30,12 @@ class LookupTable(Initializable):
 
     @property
     def W(self):
-        return self.params[0]
+        return self.parameters[0]
 
     @allocation
     def allocate(self):
-        self.params.append(shared_floatx_nans((self.length, self.dim),
-                           name='W'))
+        self.parameters.append(shared_floatx_nans((self.length, self.dim),
+                               name='W'))
 
     @initialization
     def initialize(self):

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -75,7 +75,8 @@ class Parallel(Initializable):
             self.children.append(copy.deepcopy(self.prototype))
             self.children[-1].name = "{}_{}".format(child_prefix, name)
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         for input_dim, output_dim, child in \
                 equizip(self.input_dims, self.output_dims, self.children):
             child.input_dim = input_dim
@@ -149,7 +150,8 @@ class Fork(Parallel):
         super(Fork, self).__init__(output_names, prototype=prototype,
                                    child_prefix="fork", **kwargs)
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.input_dims = [self.input_dim for name in self.output_names]
         super(Fork, self)._push_allocation_config()
 
@@ -224,7 +226,8 @@ class Distribute(Fork):
             output_names=target_names, output_dims=target_dims,
             input_dim=source_dim, prototype=prototype, **kwargs)
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.input_dim = self.source_dim
         self.output_dims = self.target_dims
         super(Distribute, self)._push_allocation_config()
@@ -322,6 +325,7 @@ class Merge(Parallel):
         # small number of outputs
         return sum(outputs)
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.output_dims = [self.output_dim for input_name in self.input_names]
         super(Merge, self)._push_allocation_config()

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -153,7 +153,7 @@ class Fork(Parallel):
     @allocation_push
     def push_allocation_config(self):
         self.input_dims = [self.input_dim for name in self.output_names]
-        super(Fork, self)._push_allocation_config()
+        super(Fork, self).push_allocation_config()
 
     @application(inputs=['input_'])
     def apply(self, input_):
@@ -230,7 +230,7 @@ class Distribute(Fork):
     def push_allocation_config(self):
         self.input_dim = self.source_dim
         self.output_dims = self.target_dims
-        super(Distribute, self)._push_allocation_config()
+        super(Distribute, self).push_allocation_config()
 
     @application
     def apply(self, **kwargs):
@@ -328,4 +328,4 @@ class Merge(Parallel):
     @allocation_push
     def push_allocation_config(self):
         self.output_dims = [self.output_dim for input_name in self.input_names]
-        super(Merge, self)._push_allocation_config()
+        super(Merge, self).push_allocation_config()

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -4,7 +4,7 @@ import copy
 from picklable_itertools.extras import equizip
 
 from blocks.bricks import Initializable, Linear
-from blocks.bricks.base import lazy, application
+from blocks.bricks.base import lazy, application, allocation_push
 from blocks.utils import pack
 
 

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -56,7 +56,7 @@ class Parallel(Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['input_dims'])
     def __init__(self, input_names, input_dims, output_dims,
                  prototype=None, child_prefix=None, **kwargs):
         super(Parallel, self).__init__(**kwargs)
@@ -141,7 +141,7 @@ class Fork(Parallel):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['input_dim'])
     def __init__(self, output_names, input_dim,  prototype=None, **kwargs):
         self.output_names = output_names
         self.input_dim = input_dim
@@ -212,7 +212,7 @@ class Distribute(Fork):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['source_name', 'target_dims'])
     def __init__(self, target_names, source_name, target_dims, source_dim,
                  prototype=None, **kwargs):
         self.target_names = target_names
@@ -307,7 +307,7 @@ class Merge(Parallel):
     array([[ 11.,  11.]]...
 
     """
-    @lazy
+    @lazy(allocation=['input_dims', 'output_dim'])
     def __init__(self, input_names, input_dims, output_dim, **kwargs):
         self.output_dim = output_dim
         super(Merge, self).__init__(

--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -56,7 +56,7 @@ class Parallel(Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy(allocation=['input_dims'])
+    @lazy(allocation=['input_dims', 'output_dims'])
     def __init__(self, input_names, input_dims, output_dims,
                  prototype=None, child_prefix=None, **kwargs):
         super(Parallel, self).__init__(**kwargs)
@@ -214,7 +214,7 @@ class Distribute(Fork):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy(allocation=['source_name', 'target_dims'])
+    @lazy(allocation=['source_dim', 'target_dims'])
     def __init__(self, target_names, source_name, target_dims, source_dim,
                  prototype=None, **kwargs):
         self.target_names = target_names

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -252,7 +252,7 @@ class SimpleRecurrent(BaseRecurrent, Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, activation, **kwargs):
         super(SimpleRecurrent, self).__init__(**kwargs)
         self.dim = dim
@@ -338,7 +338,7 @@ class LSTM(BaseRecurrent, Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, activation=None, **kwargs):
         super(LSTM, self).__init__(**kwargs)
         self.dim = dim
@@ -464,7 +464,7 @@ class GatedRecurrent(BaseRecurrent, Initializable):
         for Statistical Machine Translation*, EMNLP (2014), pp. 1724-1734.
 
     """
-    @lazy
+    @lazy(allocation=['dim'])
     def __init__(self, dim, activation=None, gate_activation=None,
                  use_update_gate=True, use_reset_gate=True, **kwargs):
         super(GatedRecurrent, self).__init__(**kwargs)
@@ -605,7 +605,7 @@ class Bidirectional(Initializable):
     """
     has_bias = False
 
-    @lazy
+    @lazy()
     def __init__(self, prototype, **kwargs):
         super(Bidirectional, self).__init__(**kwargs)
         self.prototype = prototype

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -9,7 +9,8 @@ import theano
 from theano import tensor, Variable
 
 from blocks.bricks import Initializable, Sigmoid, Tanh
-from blocks.bricks.base import Application, application, Brick, lazy
+from blocks.bricks.base import (Application, application, Brick, lazy,
+                                allocation, initialization)
 from blocks.initialization import NdarrayInitialization
 from blocks.roles import add_role, WEIGHT, BIAS
 from blocks.utils import (pack, shared_floatx_nans, dict_union, dict_subset,

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -261,7 +261,7 @@ class SimpleRecurrent(BaseRecurrent, Initializable):
 
     @property
     def W(self):
-        return self.params[0]
+        return self.parameters[0]
 
     def get_dim(self, name):
         if name == 'mask':
@@ -273,7 +273,8 @@ class SimpleRecurrent(BaseRecurrent, Initializable):
 
     @allocation
     def allocate(self):
-        self.params.append(shared_floatx_nans((self.dim, self.dim), name="W"))
+        self.parameters.append(shared_floatx_nans((self.dim, self.dim),
+                                                  name="W"))
 
     @initialization
     def initialize(self):
@@ -376,13 +377,14 @@ class LSTM(BaseRecurrent, Initializable):
         add_role(self.W_cell_to_out, WEIGHT)
         add_role(self.biases, BIAS)
 
-        self.params = [self.W_state, self.W_cell_to_in, self.W_cell_to_forget,
-                       self.W_cell_to_out, self.biases]
+        self.parameters = [self.W_state, self.W_cell_to_in,
+                           self.W_cell_to_forget, self.W_cell_to_out,
+                           self.biases]
 
     @initialization
     def initialize(self):
         self.biases_init.initialize(self.biases, self.rng)
-        for w in self.params[:-1]:
+        for w in self.parameters[:-1]:
             self.weights_init.initialize(w, self.rng)
 
     @recurrent(sequences=['inputs', 'mask'], states=['states', 'cells'],
@@ -488,15 +490,15 @@ class GatedRecurrent(BaseRecurrent, Initializable):
 
     @property
     def state_to_state(self):
-        return self.params[0]
+        return self.parameters[0]
 
     @property
     def state_to_update(self):
-        return self.params[1]
+        return self.parameters[1]
 
     @property
     def state_to_reset(self):
-        return self.params[2]
+        return self.parameters[2]
 
     def get_dim(self, name):
         if name == 'mask':
@@ -510,11 +512,11 @@ class GatedRecurrent(BaseRecurrent, Initializable):
         def new_param(name):
             return shared_floatx_nans((self.dim, self.dim), name=name)
 
-        self.params.append(new_param('state_to_state'))
-        self.params.append(new_param('state_to_update')
-                           if self.use_update_gate else None)
-        self.params.append(new_param('state_to_reset')
-                           if self.use_reset_gate else None)
+        self.parameters.append(new_param('state_to_state'))
+        self.parameters.append(new_param('state_to_update')
+                               if self.use_update_gate else None)
+        self.parameters.append(new_param('state_to_reset')
+                               if self.use_reset_gate else None)
 
     @initialization
     def initialize(self):

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -270,10 +270,12 @@ class SimpleRecurrent(BaseRecurrent, Initializable):
             return self.dim
         return super(SimpleRecurrent, self).get_dim(name)
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         self.params.append(shared_floatx_nans((self.dim, self.dim), name="W"))
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         self.weights_init.initialize(self.W, self.rng)
 
     @recurrent(sequences=['inputs', 'mask'], states=['states'],
@@ -356,7 +358,8 @@ class LSTM(BaseRecurrent, Initializable):
             return 0
         return super(LSTM, self).get_dim(name)
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         self.W_state = shared_floatx_nans((self.dim, 4*self.dim),
                                           name='W_state')
         self.W_cell_to_in = shared_floatx_nans((self.dim,),
@@ -375,7 +378,8 @@ class LSTM(BaseRecurrent, Initializable):
         self.params = [self.W_state, self.W_cell_to_in, self.W_cell_to_forget,
                        self.W_cell_to_out, self.biases]
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         self.biases_init.initialize(self.biases, self.rng)
         for w in self.params[:-1]:
             self.weights_init.initialize(w, self.rng)
@@ -500,7 +504,8 @@ class GatedRecurrent(BaseRecurrent, Initializable):
             return self.dim
         return super(GatedRecurrent, self).get_dim(name)
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         def new_param(name):
             return shared_floatx_nans((self.dim, self.dim), name=name)
 
@@ -510,7 +515,8 @@ class GatedRecurrent(BaseRecurrent, Initializable):
         self.params.append(new_param('state_to_reset')
                            if self.use_reset_gate else None)
 
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         self.weights_init.initialize(self.state_to_state, self.rng)
         if self.use_update_gate:
             self.weights_init.initialize(self.state_to_update, self.rng)

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -94,7 +94,7 @@ class BaseSequenceGenerator(Initializable):
     See :class:`.Initializable` for initialization parameters.
 
     """
-    @lazy
+    @lazy()
     def __init__(self, readout, transition, fork, **kwargs):
         super(BaseSequenceGenerator, self).__init__(**kwargs)
         self.readout = readout
@@ -367,7 +367,7 @@ class Readout(AbstractReadout, Initializable):
         change dimensions).
 
     """
-    @lazy
+    @lazy(allocation=['source_names', 'readout_dim'])
     def __init__(self, source_names, readout_dim, emitter=None,
                  feedback_brick=None, merge=None, merge_prototype=None,
                  post_merge=None, merged_dim=None, **kwargs):
@@ -449,7 +449,7 @@ class TrivialEmitter(AbstractEmitter):
     By default :meth:`cost` always returns zero tensor.
 
     """
-    @lazy
+    @lazy(allocation=['readout_dim'])
     def __init__(self, readout_dim, **kwargs):
         super(TrivialEmitter, self).__init__(**kwargs)
         self.readout_dim = readout_dim
@@ -517,7 +517,7 @@ class SoftmaxEmitter(AbstractEmitter, Initializable, Random):
 
 class TrivialFeedback(AbstractFeedback):
     """A feedback brick for the case when readout are outputs."""
-    @lazy
+    @lazy(allocation=['output_dim'])
     def __init__(self, output_dim, **kwargs):
         super(TrivialFeedback, self).__init__(**kwargs)
         self.output_dim = output_dim

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -5,7 +5,7 @@ from six import add_metaclass
 from theano import tensor
 
 from blocks.bricks import Initializable, Random, Bias
-from blocks.bricks.base import application, Brick, lazy
+from blocks.bricks.base import application, Brick, lazy, allocation_push
 from blocks.bricks.parallel import Fork, Distribute, Merge
 from blocks.bricks.lookup import LookupTable
 from blocks.bricks.recurrent import recurrent

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -115,7 +115,8 @@ class BaseSequenceGenerator(Initializable):
     def _glimpse_names(self):
         return self.transition.take_glimpses.outputs
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         # Configure readout. That involves `get_dim` requests
         # to the transition. To make sure that it answers
         # correctly we should finish its configuration first.
@@ -394,7 +395,8 @@ class Readout(AbstractReadout, Initializable):
         self.children = [self.emitter, self.feedback_brick,
                          self.merge, self.post_merge]
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.emitter.readout_dim = self.get_dim('readouts')
         self.feedback_brick.output_dim = self.get_dim('outputs')
         self.merge.input_names = self.source_names
@@ -552,7 +554,8 @@ class LookupFeedback(AbstractFeedback, Initializable):
                                   weights_init=self.weights_init)
         self.children = [self.lookup]
 
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         self.lookup.length = self.num_outputs
         self.lookup.dim = self.feedback_dim
 

--- a/blocks/graph.py
+++ b/blocks/graph.py
@@ -366,7 +366,8 @@ class Annotation(object):
         >>> from blocks.roles import COST
         >>> from blocks.utils import shared_floatx_nans
         >>> class Foo(Brick):
-        ...     def _allocate(self):
+        ...     @allocation
+        ...     def allocate(self):
         ...         W = shared_floatx_nans((10, 10))
         ...         self.add_auxiliary_variable(W.mean(), name='mean_W')
         ...     @application

--- a/blocks/select.py
+++ b/blocks/select.py
@@ -171,7 +171,7 @@ class Selector(object):
             result = [(Path([Path.BrickName(brick.name),
                              Path.ParamName(param.name)]),
                        param)
-                      for param in brick.params
+                      for param in brick.parameters
                       if not param_name or param.name == param_name]
             result = OrderedDict(result)
             for child in brick.children:

--- a/docs/bricks_overview.rst
+++ b/docs/bricks_overview.rst
@@ -75,9 +75,9 @@ When we called :attr:`.Linear.apply`, the brick automatically constructed
 the `shared Theano variables`_ needed to store its parameters. In the lifecycle
 of a brick we refer to this as *allocation*.
 
-    >>> linear.params
+    >>> linear.parameters
     [W, b]
-    >>> linear.params[1].get_value() # doctest: +SKIP
+    >>> linear.parameters[1].get_value() # doctest: +SKIP
     array([ nan,  nan,  nan,  nan,  nan])
 
 By default, all our parameters are set to ``NaN``. To initialize them, simply
@@ -85,7 +85,7 @@ call the :meth:`.Brick.initialize` method. This is the last step in the
 brick lifecycle: *initialization*.
 
     >>> linear.initialize()
-    >>> linear.params[1].get_value() # doctest: +SKIP
+    >>> linear.parameters[1].get_value() # doctest: +SKIP
     array([ 0.01,  0.01,  0.01,  0.01,  0.01])
 
 Keep in mind that at the end of the day, bricks just help you construct a Theano
@@ -136,12 +136,12 @@ implicitly when calling the ``apply`` methods, but it can also be called
 explicitly. Consider the following example:
 
     >>> linear3 = Linear(input_dim=10, output_dim=5)
-    >>> linear3.params
+    >>> linear3.parameters
     Traceback (most recent call last):
         ...
     AttributeError: 'Linear' object has no attribute 'params'
     >>> linear3.allocate()
-    >>> linear3.params
+    >>> linear3.parameters
     [W, b]
 
 Nested bricks
@@ -174,7 +174,7 @@ automatically pushed the weight matrix and biases initialization
 configuration to its children.
 
     >>> mlp.initialize()
-    >>> mlp.children[1].params[0].get_value() # doctest: +SKIP
+    >>> mlp.children[1].parameters[0].get_value() # doctest: +SKIP
     array([[-0.38312393, -1.7718271 ,  0.78074479, -0.74750996],
            ...
            [ 1.32390416, -0.56375355, -0.24268186, -2.06008577]])
@@ -206,7 +206,7 @@ configuration.
     >>> mlp.push_initialization_config()
     >>> mlp.children[0].weights_init = Constant(0.01)
     >>> mlp.initialize()
-    >>> mlp.children[0].params[0].get_value() # doctest: +SKIP
+    >>> mlp.children[0].parameters[0].get_value() # doctest: +SKIP
     array([[ 0.01,  0.01,  0.01,  0.01,  0.01,  0.01,  0.01,  0.01],
            ...
            [ 0.01,  0.01,  0.01,  0.01,  0.01,  0.01,  0.01,  0.01]])

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -74,7 +74,8 @@ class ParentBrick(Brick):
 
 
 class BrokenAllocateBrick(Brick):
-    def _push_allocation_config(self):
+    @allocation_push
+    def push_allocation_config(self):
         raise AttributeError
 
     @allocation

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -93,7 +93,7 @@ class BrokenInitializeBrick(Brick):
 class ParameterBrick(Brick):
     @allocation
     def allocate(self):
-        self.params.append(
+        self.parameters.append(
             theano.shared(numpy.zeros((10, 10), dtype=theano.config.floatX)))
 
 
@@ -144,11 +144,11 @@ def test_allocate():
     parameter_brick = ParameterBrick()
     assert not hasattr(parameter_brick, 'params')
     parameter_brick.allocate()
-    assert len(parameter_brick.params) == 1
-    parameter_brick.params[0].set_value(
+    assert len(parameter_brick.parameters) == 1
+    parameter_brick.parameters[0].set_value(
         numpy.ones((10, 10), dtype=theano.config.floatX))
     parameter_brick.allocate()
-    assert numpy.all(parameter_brick.params[0].get_value() == 0)
+    assert numpy.all(parameter_brick.parameters[0].get_value() == 0)
 
     broken_parent_brick = ParentBrick(BrokenAllocateBrick())
     assert_raises(AttributeError, broken_parent_brick.allocate)
@@ -473,8 +473,8 @@ def test_linear_nan_allocation():
                     biases_init=Constant(1))
     linear.apply(x)
     w1 = numpy.nan * numpy.zeros((16, 8))
-    w2 = linear.params[0].get_value()
+    w2 = linear.parameters[0].get_value()
     b1 = numpy.nan * numpy.zeros(8)
-    b2 = linear.params[1].get_value()
+    b2 = linear.parameters[1].get_value()
     numpy.testing.assert_equal(w1, w2)
     numpy.testing.assert_equal(b1, b2)

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -6,7 +6,8 @@ from theano import tensor
 
 from blocks.bricks import (Identity, Linear, Maxout, LinearMaxout, MLP, Tanh,
                            Sequence, Random)
-from blocks.bricks.base import Application, application, Brick, lazy
+from blocks.bricks.base import (Application, application, Brick, lazy,
+                                allocation_push, allocation, initialization)
 from blocks.bricks.parallel import Parallel, Fork
 from blocks.filter import get_application_call, get_brick
 from blocks.initialization import Constant

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -77,17 +77,20 @@ class BrokenAllocateBrick(Brick):
     def _push_allocation_config(self):
         raise AttributeError
 
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         raise AttributeError
 
 
 class BrokenInitializeBrick(Brick):
-    def _initialize(self):
+    @initialization
+    def initialize(self):
         raise AttributeError
 
 
 class ParameterBrick(Brick):
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         self.params.append(
             theano.shared(numpy.zeros((10, 10), dtype=theano.config.floatX)))
 

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -14,7 +14,7 @@ from blocks.utils import shared_floatx
 
 
 class TestBrick(Brick):
-    @lazy
+    @lazy(allocation=['config'])
     def __init__(self, config, **kwargs):
         super(TestBrick, self).__init__(**kwargs)
         self.config = config

--- a/tests/bricks/test_recurrent.py
+++ b/tests/bricks/test_recurrent.py
@@ -264,10 +264,10 @@ class TestBidirectional(unittest.TestCase):
                                       activation=Tanh(), seed=1)
         self.bidir.allocate()
         self.simple.initialize()
-        self.bidir.children[0].params[0].set_value(
-            self.simple.params[0].get_value())
-        self.bidir.children[1].params[0].set_value(
-            self.simple.params[0].get_value())
+        self.bidir.children[0].parameters[0].set_value(
+            self.simple.parameters[0].get_value())
+        self.bidir.children[1].parameters[0].set_value(
+            self.simple.parameters[0].get_value())
         self.x_val = 0.1 * numpy.asarray(
             list(itertools.permutations(range(4))),
             dtype=floatX)

--- a/tests/monitoring/test_aggregation.py
+++ b/tests/monitoring/test_aggregation.py
@@ -13,11 +13,11 @@ from blocks.utils import shared_floatx
 class TestBrick(bricks.Brick):
     @allocation
     def allocate(self):
-        self.params = [shared_floatx(2, name='V')]
+        self.parameters = [shared_floatx(2, name='V')]
 
     @application(inputs=['input_'], outputs=['output'])
     def apply(self, input_, application_call):
-        V = self.params[0]
+        V = self.parameters[0]
         mean_row_mean = mean(input_.mean(axis=1).sum(), input_.shape[0])
         application_call.add_auxiliary_variable((V ** 2).sum(),
                                                 name='V_squared')

--- a/tests/monitoring/test_aggregation.py
+++ b/tests/monitoring/test_aggregation.py
@@ -11,7 +11,8 @@ from blocks.utils import shared_floatx
 
 
 class TestBrick(bricks.Brick):
-    def _allocate(self):
+    @allocation
+    def allocate(self):
         self.params = [shared_floatx(2, name='V')]
 
     @application(inputs=['input_'], outputs=['output'])

--- a/tests/monitoring/test_aggregation.py
+++ b/tests/monitoring/test_aggregation.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 from theano import tensor
 
 from blocks import bricks
-from blocks.bricks.base import application
+from blocks.bricks.base import application, allocation
 from blocks.graph import ComputationGraph
 from blocks.monitoring.aggregation import mean
 from blocks.utils import shared_floatx

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -36,9 +36,9 @@ def test_main_loop_dump_manager():
 
         """
         W1 = (main_loop1.model.get_top_bricks()[0].linear_transformations[0]
-                              .params[0].get_value())
+                              .parameters[0].get_value())
         W2 = (main_loop2.model.get_top_bricks()[0].linear_transformations[0]
-                              .params[0].get_value())
+                              .parameters[0].get_value())
         assert numpy.all(W1 == W2)
         if check_log:
             assert sorted(list(main_loop1.log)) == sorted(list(main_loop2.log))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -36,8 +36,10 @@ def test_model():
         '/mlp/linear_0.W': 2 * numpy.ones((10, 10), dtype=floatX),
         '/mlp/linear_0.b': 3 * numpy.ones(10, dtype=floatX)}
     model3.set_param_values(param_values)
-    assert numpy.all(mlp3.linear_transformations[0].params[0].get_value() == 2)
-    assert numpy.all(mlp3.linear_transformations[0].params[1].get_value() == 3)
+    assert numpy.all(
+        mlp3.linear_transformations[0].parameters[0].get_value() == 2)
+    assert numpy.all(
+        mlp3.linear_transformations[0].parameters[1].get_value() == 3)
     got_param_values = model3.get_param_values()
     assert len(got_param_values) == len(param_values)
     for name, value in param_values.items():

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -29,13 +29,13 @@ def test_selector():
         def __init__(self, children, **kwargs):
             super(MockBrickTop, self).__init__(**kwargs)
             self.children = children
-            self.params = []
+            self.parameters = []
 
     class MockBrickBottom(Brick):
 
         def __init__(self, **kwargs):
             super(MockBrickBottom, self).__init__(**kwargs)
-            self.params = [theano.shared(0, "V"), theano.shared(0, "W")]
+            self.parameters = [theano.shared(0, "V"), theano.shared(0, "W")]
 
     b1 = MockBrickBottom(name="b1")
     b2 = MockBrickBottom(name="b2")
@@ -56,14 +56,14 @@ def test_selector():
     assert s21.bricks[0] == b2
     assert len(s21.bricks) == 1
 
-    assert s2.select("/t2/b2.V")[0] == b2.params[0]
+    assert s2.select("/t2/b2.V")[0] == b2.parameters[0]
 
     params = list(s1.get_params().items())
     assert params[0][0] == "/t1/b1.V"
-    assert params[0][1] == b1.params[0]
+    assert params[0][1] == b1.parameters[0]
     assert params[1][0] == "/t1/b1.W"
-    assert params[1][1] == b1.params[1]
+    assert params[1][1] == b1.parameters[1]
     assert params[2][0] == "/t1/b2.V"
-    assert params[2][1] == b2.params[0]
+    assert params[2][1] == b2.parameters[0]
     assert params[3][0] == "/t1/b2.W"
-    assert params[3][1] == b2.params[1]
+    assert params[3][1] == b2.parameters[1]

--- a/tests/test_variable_filter.py
+++ b/tests/test_variable_filter.py
@@ -18,8 +18,8 @@ def test_variable_filter():
     y = brick2.apply(h2)
     cg = ComputationGraph(y)
 
-    parameters = [brick1.W, brick1.b, brick2.params[0]]
-    bias = [brick1.b, brick2.params[0]]
+    parameters = [brick1.W, brick1.b, brick2.parameters[0]]
+    bias = [brick1.b, brick2.parameters[0]]
     brick1_bias = [brick1.b]
 
     # Testing filtering by role


### PR DESCRIPTION
WIP, but this is basically a rewrite of `blocks/bricks/base.py`. It implements the `lazy` decorator as discussed in https://github.com/bartvm/blocks/issues/337#issuecomment-75884106 with @rizar and @fvisin. It also ditches metaclasses in favor of class decorators; I need to confirm later on that these actually pickle well, but my initial tests seem to show they do.

Currently it's still very messy, but it cuts 20% of the lines `base.py`. There are a few functionalities which took acrobatics to support, which I'm not sure are actually used, so I would propose removing them if at all possible. Notably, the ability to set the attributes of applications i.e. to do `brick.apply.inputs = ['x']`. This is annoying because it prevents us from actually turning `brick.apply.inputs` in a bound method (it's impossible to set an attribute of an `instancemethod`).

This also switches to using decorators for `allocation`, `initialization`, etc. as suggested in https://github.com/bartvm/blocks/issues/39. Expecting a user to override private methods is pretty bad form I think, so we need to either change the name of the method to something without a leading underscore, or use decorators. I went with decorators for now, because otherwise it's confusing for users to implement one method, but call another.