### PR TITLE
Refactor RemoveNotFinite

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -732,8 +732,8 @@ class RemoveNotFinite(StepRule):
         self.scaler = scaler
 
     def compute_step(self, param, previous_step):
-        not_finite = tensor.or_(
-            tensor.isnan(previous_step), tensor.isinf(previous_step)).sum()
+        not_finite = (tensor.isnan(previous_step).sum() +
+                      tensor.isinf(previous_step).sum())
         step = tensor.switch(
             not_finite > 0, (1 - self.scaler) * param, previous_step)
         return step, []

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -710,29 +710,32 @@ class RemoveNotFinite(StepRule):
 
     Replaces a step (the parameter update of a single shared variable)
     which contains non-finite elements (such as ``inf`` or ``NaN``) with a
-    scaled version of the parameters being updated instead.
+    step rescaling the parameters.
 
     Parameters
     ----------
     scaler : float, optional
         The scaling applied to the parameter in case the step contains
-        non-finite elements. Defaults to 0.1.
+        non-finite elements. Defaults to 1, which means that parameters
+        will not be changed.
 
     Notes
     -----
+    This rule should be applied last!
+
     This trick was originally used in the GroundHog_ framework.
 
     .. _GroundHog: https://github.com/lisa-groundhog/GroundHog
 
     """
-    def __init__(self, scaler=0.1):
+    def __init__(self, scaler=1):
         self.scaler = scaler
 
     def compute_step(self, param, previous_step):
         not_finite = tensor.any(tensor.or_(
             tensor.isnan(previous_step), tensor.isinf(previous_step)))
-        step = tensor.switch(not_finite, self.scaler * param, previous_step)
-
+        step = tensor.switch(
+            not_finite, (1 - self.scaler) * param, previous_step)
         return step, []
 
 

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -732,10 +732,10 @@ class RemoveNotFinite(StepRule):
         self.scaler = scaler
 
     def compute_step(self, param, previous_step):
-        not_finite = tensor.any(tensor.or_(
-            tensor.isnan(previous_step), tensor.isinf(previous_step)))
+        not_finite = tensor.or_(
+            tensor.isnan(previous_step), tensor.isinf(previous_step)).sum()
         step = tensor.switch(
-            not_finite, (1 - self.scaler) * param, previous_step)
+            not_finite > 0, (1 - self.scaler) * param, previous_step)
         return step, []
 
 

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -226,10 +226,12 @@ def test_remove_not_finite():
     rule1 = RemoveNotFinite(0.1)
     rule2 = RemoveNotFinite()
 
-    gradients = {1: shared_floatx(numpy.nan), 2: shared_floatx(numpy.inf)}
+    gradients = {1: shared_floatx(numpy.nan), 2: shared_floatx(numpy.inf),
+                 3: 0.123}
     rval1, _ = rule1.compute_steps(gradients)
     assert_allclose(rval1[1].eval(), 0.9)
     assert_allclose(rval1[2].eval(), 1.8)
+    assert_allclose(rval1[3].eval(), 0.123)
     rval2, _ = rule2.compute_steps(gradients)
     assert_allclose(rval2[1].eval(), 0.0)
     assert_allclose(rval2[2].eval(), 0.0)

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -223,16 +223,16 @@ def test_adam():
 
 
 def test_remove_not_finite():
-    rule1 = RemoveNotFinite()
-    rule2 = RemoveNotFinite(1.)
+    rule1 = RemoveNotFinite(0.1)
+    rule2 = RemoveNotFinite()
 
     gradients = {1: shared_floatx(numpy.nan), 2: shared_floatx(numpy.inf)}
     rval1, _ = rule1.compute_steps(gradients)
-    assert_allclose(rval1[1].eval(), 0.1)
-    assert_allclose(rval1[2].eval(), 0.2)
+    assert_allclose(rval1[1].eval(), 0.9)
+    assert_allclose(rval1[2].eval(), 1.8)
     rval2, _ = rule2.compute_steps(gradients)
-    assert_allclose(rval2[1].eval(), 1.0)
-    assert_allclose(rval2[2].eval(), 2.0)
+    assert_allclose(rval2[1].eval(), 0.0)
+    assert_allclose(rval2[2].eval(), 0.0)
 
 
 class DummyUpdatesStepRule(StepRule):


### PR DESCRIPTION
`RemoveNotFinite` was quite confusing. It's parameter called `scaler` in fact meant that `1 - scaler` scaling will be applied. It was also never clearly said in the docs that it must be applied last. Finally, `0.1` is a kind of random default, a better default being not touching the parameters when nans are encountered.

All these things should be fixed in this PR. 

@ejls, @orhanf , you might be interested.

@memimo , you are the author.