### PR TITLE
removed transposes to speed up LSTM

### DIFF
--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -430,8 +430,10 @@ class LSTM(BaseRecurrent, Initializable):
             Next cell activations of the network.
 
         """
+
         def slice_last(x, no):
-            return x.T[no*self.dim: (no+1)*self.dim].T
+            return x[:, no*self.dim: (no+1)*self.dim]
+
         nonlinearity = self.children[0].apply
 
         activation = tensor.dot(states, self.W_state) + inputs

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -430,7 +430,6 @@ class LSTM(BaseRecurrent, Initializable):
             Next cell activations of the network.
 
         """
-
         def slice_last(x, no):
             return x[:, no*self.dim: (no+1)*self.dim]
 


### PR DESCRIPTION
Running the @rizar his benchmark using a GTX 580 I got this as a baseline result:

| | 100|250|1000|2000 |
|---|---|---|---|---|
| SimpleRecurrent|13|16|62|85 |
| GatedRecurrent|25|34|119|232 |
| LSTM|52|97|280|929 |

And this after removing the transpose:

| | 100|250|1000|2000 |
|---|---|---|---|---|
| SimpleRecurrent|12|16|62|85 |
| GatedRecurrent|25|34|119|231 |
| LSTM|44|85|248|611 |

So for larger networks the difference is substantial while for smaller networks the difference is not that big but still nice.