### PR TITLE
Use FAST_COMPILE for tests. Fixes #644.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ script:
   - |
       if [[ $TESTS == 'blocks' ]]; then
         coverage run -p --source=blocks -m nose2.__main__ -v doctests
+        export THEANO_FLAGS=$THEANO_FLAGS,cxx=
         coverage run -p --source=blocks -m nose2.__main__ -v tests
       fi
   - |

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -127,7 +127,7 @@ def test_attention_recurrent():
     for i in range(batch_size):
         last = int(input_mask_vals[:, i].sum())
         for j in range(last, input_length):
-            assert_allclose(weight_vals[last, i], weight_vals[j, i])
+            assert_allclose(weight_vals[last, i], weight_vals[j, i], 1e-5)
 
     # freeze sums
     assert_allclose(weight_vals.sum(), input_length * batch_size, 1e-5)


### PR DESCRIPTION
On my computer this reduces runtime from `Ran 131 tests in 110.066s` to `Ran 131 tests in 9.579s`. However, it also gives me:
```
======================================================================
FAIL: tests.monitoring.test_aggregation.FunctionTestCase (test_mean_aggregator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vanmerb/lisa/blocks/tests/monitoring/test_aggregation.py", line 88, in test_mean_aggregator
    assert_allclose(DatasetEvaluator([y]).evaluate(data_stream)['y'],
  File "/home/vanmerb/lisa/blocks/blocks/monitoring/evaluators.py", line 320, in evaluate
    self.process_batch(batch)
  File "/home/vanmerb/lisa/blocks/blocks/monitoring/evaluators.py", line 293, in process_batch
    numerical_values = self._accumulate_fun(**batch)
  File "/home/vanmerb/lisa/Theano/theano/compile/function_module.py", line 599, in __call__
    outputs = self.fn()
  File "/home/vanmerb/lisa/Theano/theano/gof/link.py", line 526, in streamline_default_f
    raise_with_op(node, thunk)
  File "/home/vanmerb/lisa/Theano/theano/gof/link.py", line 522, in streamline_default_f
    thunk()
  File "/home/vanmerb/lisa/Theano/theano/gof/op.py", line 782, in rval
    r = p(n, [x[0] for x in i], o)
  File "/home/vanmerb/lisa/Theano/theano/tensor/elemwise.py", line 816, in perform
    assert max(values) <= 1
AssertionError:
Apply node that caused the error: Elemwise{add,no_inplace}(y, shared_y)
Inputs types: [TensorType(float32, vector), TensorType(float32, vector)]
Inputs shapes: [(2,), (0,)]
Inputs strides: [(4,), (4,)]
Inputs values: [array([  2.,  45.], dtype=float32), array([], dtype=float32)]

Backtrace when the node is created:
  File "/home/vanmerb/lisa/blocks/blocks/monitoring/aggregation.py", line 112, in get_aggregator
    self.numerator + numerator_acc,

HINT: Use the Theano flag 'exception_verbosity=high' for a debugprint and storage map footprint of this apply node.

----------------------------------------------------------------------
Ran 131 tests in 9.579s

FAILED (failures=1)
```