### PR TITLE
Reduce build matrix size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,16 @@ branches:
     - master
     - stable
 language: python
-python:
-  - "2.7"
-  - "3.4"
-env:
-  - TESTS=blocks FLOATX=float32
-  - TESTS=blocks FLOATX=float64
-  - TESTS=blocks-examples FLOATX=float32
-  - TESTS=blocks-examples FLOATX=float64
+matrix:
+  include:
+    - python: 2.7
+      env: TESTS=blocks FLOATX=float32
+    - python: 3.4
+      env: TESTS=blocks FLOATX=float64
+    - python: 2.7
+      env: TESTS=blocks-examples FLOATX=float32
+    - python: 3.4
+      env: TESTS=blocks-examples FLOATX=float64
 before_install:
   - # Setup Python environment with BLAS libraries
   - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh


### PR DESCRIPTION
This does the same as we did for Pylearn2 at one point: We assume that Python 2 vs. 3 and float32 vs float64 are completely complementary, so instead of running each combination, we run Python 2 with float32 and Python 3 with float64. Should speed up Travis.

Contributes to #644.