### PR TITLE
Xavier weight initialization

### DIFF
--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -224,6 +224,7 @@ class Sparse(NdarrayInitialization):
             weights[i, random_indices] = values[i]
         return weights
 
+
 class GlorotBengio(NdarrayInitialization):
     """Initialize parameters with Glorot-Bengio method.
 
@@ -235,6 +236,8 @@ class GlorotBengio(NdarrayInitialization):
     ----------
     scale : float
         1 for linear/tanh/sigmoid. 2 for RELU
+    normal : bool
+        Perform sampling from normal distribution. By defaut use uniform.
 
     Notes
     -----
@@ -245,10 +248,14 @@ class GlorotBengio(NdarrayInitialization):
       artificial intelligence and statistics, 249-256
       http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
     """
-    def __init__(self, scale=1):
+    def __init__(self, scale=1, normal=False):
         self._scale = float(scale)
+        self._normal = normal
 
     def generate(self, rng, shape):
-        std = numpy.sqrt(self._scale/shape[-1])
-        m = rng.normal(0., std, size=shape)
+        w = numpy.sqrt(self._scale/shape[-1])
+        if self._normal:
+            m = rng.normal(0., w, size=shape)
+        else:
+            m = rng.uniform(-w, w, size=shape)
         return m.astype(theano.config.floatX)

--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -223,3 +223,31 @@ class Sparse(NdarrayInitialization):
                                                  replace=False)
             weights[i, random_indices] = values[i]
         return weights
+
+class Xavier(NdarrayInitialization):
+    """Initialize with Gaussian distribution with Xavier parameters.
+
+    Use the following gaussian parameters: mean=0 and std=sqrt(scale/Nin)
+
+
+    Parameters
+    ----------
+    scale : float
+        1 for linear/tanh/sigmoid. 2 for RELU
+
+    Notes
+    -----
+    For more information, see [GLOROT]_.
+
+    .. [GLOROT] Glorot et al. *Understanding the difficulty of training
+      deep feedforward neural networks*, International conference on
+      artificial intelligence and statistics, 249-256
+      http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf
+    """
+    def __init__(self, scale=1):
+        self._scale = float(scale)
+
+    def generate(self, rng, shape):
+        std = numpy.sqrt(self._scale/shape[-1])
+        m = rng.normal(0., std, size=shape)
+        return m.astype(theano.config.floatX)

--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -224,10 +224,11 @@ class Sparse(NdarrayInitialization):
             weights[i, random_indices] = values[i]
         return weights
 
-class Xavier(NdarrayInitialization):
-    """Initialize with Gaussian distribution with Xavier parameters.
+class GlorotBengio(NdarrayInitialization):
+    """Initialize with Gaussian distribution with Glorot-Bengio parameters.
 
-    Use the following gaussian parameters: mean=0 and std=sqrt(scale/Nin)
+    Use the following gaussian parameters: mean=0 and std=sqrt(scale/Nin).
+    In some circles this method is also called Xavier weight initialization.
 
 
     Parameters

--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -225,7 +225,7 @@ class Sparse(NdarrayInitialization):
         return weights
 
 class GlorotBengio(NdarrayInitialization):
-    """Initialize with Gaussian distribution with Glorot-Bengio parameters.
+    """Initialize parameters with Glorot-Bengio method.
 
     Use the following gaussian parameters: mean=0 and std=sqrt(scale/Nin).
     In some circles this method is also called Xavier weight initialization.

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -4,7 +4,7 @@ import theano
 from numpy.testing import assert_equal, assert_allclose, assert_raises
 
 from blocks.initialization import Constant, IsotropicGaussian, Sparse
-from blocks.initialization import Uniform, Orthogonal
+from blocks.initialization import Uniform, Orthogonal, GlorotBengio
 
 
 def test_constant():
@@ -120,3 +120,24 @@ def test_orthogonal():
     yield check_orthogonal, rng, (50, 50)
     yield check_orthogonal, rng, (50, 51)
     yield check_orthogonal, rng, (51, 50)
+
+
+def test_glorotbengio():
+    rng = numpy.random.RandomState(1)
+
+    def check_glorotbengio(rng, scale, normal, shape):
+        weights = GlorotBengio(scale=scale, normal=normal) \
+                          .generate(rng, shape)
+        assert weights.shape == shape
+        assert weights.dtype == theano.config.floatX
+        assert_allclose(weights.mean(), 0., atol=1e-2)
+        w_ = numpy.sqrt(scale/float(shape[-1]))
+        if normal:
+            std_ = w_
+        else:
+            std_ = 2. * w_ / numpy.sqrt(12.)
+        assert_allclose(std_, weights.std(), atol=1e-2)
+
+    yield check_glorotbengio, rng, 1, True, (500, 600)
+    yield check_glorotbengio, rng, 1, False, (600, 500)
+    yield check_glorotbengio, rng, 2, True, (700, 300)


### PR DESCRIPTION
The method is called Xavier after the inventor first name and not his last name Glorot.
This is the standard name used in the industry, for example, see Caffee or http://deepdish.io/2015/02/24/network-initialization/
