### PR TITLE
Add a basic early stopping extension.

### DIFF
--- a/blocks/extensions/stopping.py
+++ b/blocks/extensions/stopping.py
@@ -12,13 +12,22 @@ class FinishIfNoImprovementAfter(FinishAfter):
         The name of the log record to look for which indicates a new
         best performer has been found.  Note that the value of this
         record is not inspected.
+    patience_log_record : str, optional
+        The name under which to record the number of iterations we
+        are currently willing to wait for a new best performer.
+        Defaults to `notification_name + 'patience'`.
 
     """
-    def __init__(self, iterations, notification_name, **kwargs):
+    def __init__(self, iterations, notification_name, patience_log_record=None,
+                 **kwargs):
         self.iterations = iterations
         self.notification_name = notification_name
         kwargs.setdefault('after_batch', True)
         self.last_best = None
+        if patience_log_record is None:
+            self.patience_log_record = notification_name + '_patience'
+        else:
+            self.patience_log_record = patience_log_record
         super(FinishIfNoImprovementAfter, self).__init__(**kwargs)
 
     def update_best(self):
@@ -30,6 +39,8 @@ class FinishIfNoImprovementAfter(FinishAfter):
         self.update_best()
         iters_since = (self.main_loop.log.status['iterations_done'] -
                        self.last_best)
+        patience = self.iterations - iters_since
+        self.main_loop.log.current_row[self.patience_log_record] = patience
         if iters_since >= self.iterations:
             super(FinishIfNoImprovementAfter, self).do(which_callback,
                                                        *args)

--- a/blocks/extensions/stopping.py
+++ b/blocks/extensions/stopping.py
@@ -1,0 +1,35 @@
+from . import FinishAfter
+
+
+class FinishIfNoImprovementAfter(FinishAfter):
+    """Stop after improvements have ceased for a given period.
+
+    Parameters
+    ----------
+    iterations : int
+        The number of iterations to wait for a new best.
+    notification_name : str
+        The name of the log record to look for which indicates a new
+        best performer has been found.  Note that the value of this
+        record is not inspected.
+
+    """
+    def __init__(self, iterations, notification_name, **kwargs):
+        self.iterations = iterations
+        self.notification_name = notification_name
+        kwargs.setdefault('after_batch', True)
+        self.last_best = None
+        super(FinishIfNoImprovementAfter, self).__init__(**kwargs)
+
+    def update_best(self):
+        # Here mainly so we can easily subclass different criteria.
+        if self.notification_name in self.main_loop.log.current_row:
+            self.last_best = self.main_loop.log.status['iterations_done']
+
+    def do(self, which_callback, *args):
+        self.update_best()
+        iters_since = (self.main_loop.log.status['iterations_done'] -
+                       self.last_best)
+        if iters_since >= self.iterations:
+            super(FinishIfNoImprovementAfter, self).do(which_callback,
+                                                       *args)

--- a/blocks/extensions/stopping.py
+++ b/blocks/extensions/stopping.py
@@ -6,26 +6,43 @@ class FinishIfNoImprovementAfter(FinishAfter):
 
     Parameters
     ----------
-    iterations : int
-        The number of iterations to wait for a new best.
     notification_name : str
         The name of the log record to look for which indicates a new
         best performer has been found.  Note that the value of this
         record is not inspected.
+    iterations : int, optional
+        The number of iterations to wait for a new best. Exactly one of
+        `iterations` or `epochs` must be not `None` (default).
+    epochs : int, optional
+        The number of epochs to wait for a new best. Exactly one of
+        `iterations` or `epochs` must be not `None` (default).
     patience_log_record : str, optional
         The name under which to record the number of iterations we
         are currently willing to wait for a new best performer.
-        Defaults to `notification_name + 'patience'`.
+        Defaults to `notification_name + '_patience_epochs'` or
+        `notification_name + '_patience_iterations'`, depending
+        which measure is being used.
+
+    Notes
+    -----
+    By default, runs after each epoch. This can be manipulated via
+    keyword arguments (see :class:`blocks.extensions.SimpleExtension`).
 
     """
-    def __init__(self, iterations, notification_name, patience_log_record=None,
-                 **kwargs):
-        self.iterations = iterations
+    def __init__(self, notification_name, iterations=None, epochs=None,
+                 patience_log_record=None, **kwargs):
+        if (epochs is None) == (iterations is None):
+            raise ValueError("Need exactly one of epochs or iterations "
+                             "to be specified")
         self.notification_name = notification_name
-        kwargs.setdefault('after_batch', True)
-        self.last_best = None
+        self.iterations = iterations
+        self.epochs = epochs
+        kwargs.setdefault('after_epoch', True)
+        self.last_best_iter = self.last_best_epoch = None
         if patience_log_record is None:
-            self.patience_log_record = notification_name + '_patience'
+            self.patience_log_record = (notification_name + '_patience' +
+                                        ('_epochs' if self.epochs is not None
+                                         else '_iterations'))
         else:
             self.patience_log_record = patience_log_record
         super(FinishIfNoImprovementAfter, self).__init__(**kwargs)
@@ -33,17 +50,24 @@ class FinishIfNoImprovementAfter(FinishAfter):
     def update_best(self):
         # Here mainly so we can easily subclass different criteria.
         if self.notification_name in self.main_loop.log.current_row:
-            self.last_best = self.main_loop.log.status['iterations_done']
+            self.last_best_iter = self.main_loop.log.status['iterations_done']
+            self.last_best_epoch = self.main_loop.log.status['epochs_done']
 
     def do(self, which_callback, *args):
         self.update_best()
         # If we haven't encountered a best yet, then we should just bail.
-        if self.last_best is None:
+        if self.last_best_iter is None:
             return
-        iters_since = (self.main_loop.log.status['iterations_done'] -
-                       self.last_best)
-        patience = self.iterations - iters_since
+        if self.epochs is not None:
+            since = (self.main_loop.log.status['epochs_done'] -
+                     self.last_best_epoch)
+            patience = self.epochs - since
+        else:
+            since = (self.main_loop.log.status['iterations_done'] -
+                     self.last_best_iter)
+            patience = self.iterations - since
+
         self.main_loop.log.current_row[self.patience_log_record] = patience
-        if iters_since >= self.iterations:
+        if patience == 0:
             super(FinishIfNoImprovementAfter, self).do(which_callback,
                                                        *args)

--- a/blocks/extensions/stopping.py
+++ b/blocks/extensions/stopping.py
@@ -37,6 +37,9 @@ class FinishIfNoImprovementAfter(FinishAfter):
 
     def do(self, which_callback, *args):
         self.update_best()
+        # If we haven't encountered a best yet, then we should just bail.
+        if self.last_best is None:
+            return
         iters_since = (self.main_loop.log.status['iterations_done'] -
                        self.last_best)
         patience = self.iterations - iters_since

--- a/tests/extensions/test_stopping.py
+++ b/tests/extensions/test_stopping.py
@@ -1,67 +1,98 @@
+import unittest
 from blocks.extensions.stopping import FinishIfNoImprovementAfter
 
 
 class FakeLog(object):
-    current_row = {}
-    status = {'iterations_done': 0}
+    epoch_length = 4
+
+    def __init__(self):
+        self.current_row = {}
+        self.status = {'iterations_done': 0, 'epochs_done': 0}
+
+    def advance(self, epochs):
+        self.status['iterations_done'] += self.epoch_length if epochs else 1
+        self.status['epochs_done'] += (1 if epochs
+                                       else (self.status['iterations_done'] //
+                                             self.epoch_length))
 
 
 class FakeMainLoop(object):
-    log = FakeLog()
+    def __init__(self):
+        self.log = FakeLog()
 
 
-def test_finish_if_no_improvement_after():
-    main_loop = FakeMainLoop()
+class FinishIfNoImprovementAfterTester(unittest.TestCase):
+    def check_not_stopping(self):
+        finish = self.main_loop.log.current_row.get(
+            'training_finish_requested', False)
+        self.assertFalse(finish)
 
-    def check_not_stopping():
-        finish = main_loop.log.current_row.get('training_finish_requested',
-                                               False)
-        assert not finish
+    def check_stopping(self):
+        finish = self.main_loop.log.current_row.get(
+            'training_finish_requested', False)
+        self.assertTrue(finish)
 
-    def check_stopping():
-        finish = main_loop.log.current_row.get('training_finish_requested',
-                                               False)
-        assert finish
+    def check_log(self, record_name, value):
+        self.assertEqual(self.main_loop.log.current_row[record_name], value)
 
-    ext = FinishIfNoImprovementAfter(3, 'bananas')
-    ext.main_loop = main_loop
-    # This should silently pass, since there has been no new best set,
-    # and 'bananas' is not in the log's current row.
-    ext.do('after_batch')
-    # First is a new best.
-    main_loop.log.current_row['bananas'] = True
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 3
-    check_not_stopping()
-    # No best found for another  2 iterations.
-    del main_loop.log.current_row['bananas']
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 2
-    check_not_stopping()
-    # One iteration down, one to go.
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 1
-    check_not_stopping()
-    # Oh look, a new best!
-    main_loop.log.current_row['bananas'] = True
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 3
-    check_not_stopping()
-    # Now, run out our patience. 3 iterations with no best.
-    del main_loop.log.current_row['bananas']
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 2
-    check_not_stopping()
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 1
-    check_not_stopping()
-    main_loop.log.status['iterations_done'] += 1
-    ext.do('after_batch')
-    assert main_loop.log.current_row['bananas_patience'] == 0
-    check_stopping()
+    def setUp(self):
+        self.main_loop = FakeMainLoop()
+
+    def check_finish_if_no_improvement_after(self, ext, epochs=False):
+        # ext = FinishIfNoImprovementAfter('bananas', iterations=3)
+        ext.main_loop = self.main_loop
+        # This should silently pass, since there has been no new best set,
+        # and 'bananas' is not in the log's current row.
+        which_callback = 'after_batch' if not epochs else 'after_epoch'
+        log_entry = 'bananas_patience_' + (
+            'iterations' if not epochs else 'epochs')
+        ext.do(which_callback)
+        # First is a new best.
+        self.main_loop.log.current_row['bananas'] = True
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 3)
+        self.check_not_stopping()
+        # No best found for another  2 iterations.
+        del self.main_loop.log.current_row['bananas']
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 2)
+        self.check_not_stopping()
+        # One iteration down, one to go.
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 1)
+        self.check_not_stopping()
+        # Oh look, a new best!
+        self.main_loop.log.current_row['bananas'] = True
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 3)
+        self.check_not_stopping()
+        # Now, run out our patience. 3 iterations with no best.
+        del self.main_loop.log.current_row['bananas']
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 2)
+        self.check_not_stopping()
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 1)
+        self.check_not_stopping()
+        self.main_loop.log.advance(epochs)
+        ext.do(which_callback)
+        self.check_log(log_entry, 0)
+        self.check_stopping()
+
+    def test_finish_if_no_improvement_after_iterations(self):
+        ext = FinishIfNoImprovementAfter('bananas', iterations=3)
+        self.check_finish_if_no_improvement_after(ext, epochs=False)
+
+    def test_finish_if_no_improvement_after_epochs(self):
+        ext = FinishIfNoImprovementAfter('bananas', epochs=3)
+        self.check_finish_if_no_improvement_after(ext, epochs=True)
+
+    def test_finish_if_no_improvement_after_specify_both(self):
+        self.assertRaises(ValueError, FinishIfNoImprovementAfter, 'boo',
+                          epochs=4, iterations=5)

--- a/tests/extensions/test_stopping.py
+++ b/tests/extensions/test_stopping.py
@@ -29,29 +29,36 @@ def test_finish_if_no_improvement_after():
     main_loop.log.current_row['bananas'] = True
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 3
     check_not_stopping()
     # No best found for another  2 iterations.
     del main_loop.log.current_row['bananas']
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 2
     check_not_stopping()
     # One iteration down, one to go.
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 1
     check_not_stopping()
     # Oh look, a new best!
     main_loop.log.current_row['bananas'] = True
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 3
     check_not_stopping()
     # Now, run out our patience. 3 iterations with no best.
     del main_loop.log.current_row['bananas']
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 2
     check_not_stopping()
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 1
     check_not_stopping()
     main_loop.log.status['iterations_done'] += 1
     ext.do('after_batch')
+    assert main_loop.log.current_row['bananas_patience'] == 0
     check_stopping()

--- a/tests/extensions/test_stopping.py
+++ b/tests/extensions/test_stopping.py
@@ -1,0 +1,57 @@
+from blocks.extensions.stopping import FinishIfNoImprovementAfter
+
+
+class FakeLog(object):
+    current_row = {}
+    status = {'iterations_done': 0}
+
+
+class FakeMainLoop(object):
+    log = FakeLog()
+
+
+def test_finish_if_no_improvement_after():
+    main_loop = FakeMainLoop()
+
+    def check_not_stopping():
+        finish = main_loop.log.current_row.get('training_finish_requested',
+                                               False)
+        assert not finish
+
+    def check_stopping():
+        finish = main_loop.log.current_row.get('training_finish_requested',
+                                               False)
+        assert finish
+
+    ext = FinishIfNoImprovementAfter(3, 'bananas')
+    ext.main_loop = main_loop
+    # First is a new best.
+    main_loop.log.current_row['bananas'] = True
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_not_stopping()
+    # No best found for another  2 iterations.
+    del main_loop.log.current_row['bananas']
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_not_stopping()
+    # One iteration down, one to go.
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_not_stopping()
+    # Oh look, a new best!
+    main_loop.log.current_row['bananas'] = True
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_not_stopping()
+    # Now, run out our patience. 3 iterations with no best.
+    del main_loop.log.current_row['bananas']
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_not_stopping()
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_not_stopping()
+    main_loop.log.status['iterations_done'] += 1
+    ext.do('after_batch')
+    check_stopping()

--- a/tests/extensions/test_stopping.py
+++ b/tests/extensions/test_stopping.py
@@ -25,6 +25,9 @@ def test_finish_if_no_improvement_after():
 
     ext = FinishIfNoImprovementAfter(3, 'bananas')
     ext.main_loop = main_loop
+    # This should silently pass, since there has been no new best set,
+    # and 'bananas' is not in the log's current row.
+    ext.do('after_batch')
     # First is a new best.
     main_loop.log.current_row['bananas'] = True
     main_loop.log.status['iterations_done'] += 1


### PR DESCRIPTION
Fixes #327. Works in tandem with `TrackTheBest`. More nuanced implementations are possible (i.e. to specify a certain relative improvement is necessary) but those can be added as subclasses. CC @rizar.

A quick review would be appreciated.