### PR TITLE
Enable namespace packages for blocks-extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl --file req-travis-conda.txt
   - pip install -q -r req-travis-pip.txt
 script:
-  - pip install . -r requirements.txt # Tests setup.py
+  - pip install -e . -r requirements.txt # Tests setup.py
   - curl -O https://raw.githubusercontent.com/bartvm/fuel/master/.travis-data.sh | bash -s -- mnist
   - # Must export environment variable so that the subprocess is aware of it
   - export THEANO_FLAGS=floatX=$FLOATX,optimizer=fast_compile

--- a/blocks/__init__.py
+++ b/blocks/__init__.py
@@ -1,4 +1,5 @@
 """The blocks library for parametrized Theano ops."""
 # Scary warning: Adding code to this file can break namespace packages
 # See https://pythonhosted.org/setuptools/setuptools.html#namespace-packages
+__import__("pkg_resources").declare_namespace(__name__)
 __version__ = '0.0.1'


### PR DESCRIPTION
The namespace package seems to throw `coverage.py` off, it runs the installed files of Blocks but measures the Git copy, resulting in 0% coverage. Installing in editable mode fixes that.