### PR TITLE
Remove Pandas dependency

### DIFF
--- a/blocks/log.py
+++ b/blocks/log.py
@@ -2,12 +2,6 @@
 from collections import defaultdict
 from numbers import Integral
 
-try:
-    from pandas import DataFrame
-    PANDAS_AVAILABLE = True
-except ImportError:
-    PANDAS_AVAILABLE = False
-
 
 class TrainingLog(defaultdict):
     """Base class for training logs.
@@ -64,10 +58,3 @@ class TrainingLog(defaultdict):
     @property
     def last_epoch_row(self):
         return self[self.status['_epoch_ends'][-1]]
-
-    def to_dataframe(self):
-        """Convert a log into a :class:`.DataFrame`."""
-        if not PANDAS_AVAILABLE:
-            raise ImportError("The pandas library is not found. You can"
-                              " install it with pip.")
-        return DataFrame.from_dict(self, orient='index')

--- a/blocks/log.py
+++ b/blocks/log.py
@@ -22,6 +22,17 @@ class TrainingLog(defaultdict):
         By default it contains ``iterations_done``, ``epochs_done`` and
         ``_epoch_ends`` (a list of time stamps when epochs ended).
 
+    Notes
+    -----
+    For analysis of the logs, it can be useful to convert the log to a
+    Pandas_ data frame:
+
+    .. code:: python
+
+       df = DataFrame.from_dict(log, orient='index')
+
+    .. _Pandas: http://pandas.pydata.org
+
     """
     def __init__(self):
         super(TrainingLog, self).__init__(dict)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,7 @@ intersphinx_mapping = {
     'theano': ('http://theano.readthedocs.org/en/latest/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
-    'python': ('http://docs.python.org/3.4', None),
-    'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None)
+    'python': ('http://docs.python.org/3.4', None)
 }
 
 

--- a/req-travis-conda.txt
+++ b/req-travis-conda.txt
@@ -2,7 +2,6 @@ coverage==3.7.1
 cython==0.22
 h5py==2.5.0
 numpy==1.9.2
-pandas==0.16.1
 pytables=3.1.1
 six==1.9.0
 toolz==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy==1.9.2
 six==1.9.0
-pandas==0.16.1
 progressbar2==2.7.3
 PyYaml==3.11
 toolz==0.7.2

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,8 @@ setup(
     packages=find_packages(exclude=['examples', 'docs', 'doctests', 'tests']),
     scripts=['bin/blocks-continue'],
     setup_requires=['numpy'],
-    install_requires=['numpy', 'six', 'pyyaml', 'pandas', 'toolz',
-                      'theano', 'picklable-itertools', 'progressbar2',
-                      'fuel'],
+    install_requires=['numpy', 'six', 'pyyaml', 'toolz', 'theano',
+                      'picklable-itertools', 'progressbar2', 'fuel'],
     extras_require={
         'test': ['nose', 'nose2'],
         'docs': ['sphinx', 'sphinxcontrib-napoleon', 'sphinx-rtd-theme']


### PR DESCRIPTION
So lately I've grown a bit annoyed that every time I install Blocks on e.g. a cluster it spends a long time installing and compiling Pandas, even though the only call to Pandas in the entire library is a one-liner:
```python
DataFrame.from_dict(self, orient='index')
```

I suggest we simplify the installation a bit by removing Pandas from the dependencies, and let users call `DataFrame.from_dict(self, orient='index')` manually.