### PR TITLE
Stabilize attention energies

### DIFF
--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -221,6 +221,8 @@ class GenericSequenceAttention(AbstractAttention):
             as `energies`.
 
         """
+        # Stabilize energies first and then exponentiate
+        energies = energies - energies.max(axis=0)
         unnormalized_weights = tensor.exp(energies)
         if attended_mask:
             unnormalized_weights *= attended_mask

--- a/tests/bricks/test_attention.py
+++ b/tests/bricks/test_attention.py
@@ -155,3 +155,28 @@ def test_compute_weights_with_zero_mask():
         numpy.zeros((attended_length, batch_size)))
     weights = attention.compute_weights(energies, mask).eval()
     assert numpy.all(numpy.isfinite(weights))
+
+
+def test_stable_attention_weights():
+    state_dim = 2
+    attended_dim = 3
+    match_dim = 4
+    attended_length = 5
+    batch_size = 6
+
+    attention = SequenceContentAttention(
+        state_names=["states"], state_dims=[state_dim],
+        attended_dim=attended_dim, match_dim=match_dim,
+        weights_init=IsotropicGaussian(0.5),
+        biases_init=Constant(0))
+    attention.initialize()
+
+    # Random high energies with mu=800, sigma=50
+    energies_val = (
+        50. * numpy.random.randn(attended_length, batch_size) + 800
+        ).astype(theano.config.floatX)
+    energies = tensor.as_tensor_variable(energies_val)
+    mask = tensor.as_tensor_variable(
+        numpy.ones((attended_length, batch_size)))
+    weights = attention.compute_weights(energies, mask).eval()
+    assert numpy.all(numpy.isfinite(weights))


### PR DESCRIPTION
I've managed to accumulate enough energies to make exp overflow in some case, resulting NaN propagation all the way for machine translation. This is to stabilize as its done in regular softmax.