### PR TITLE
Use numbers.Integral to check for integer-ness.

### DIFF
--- a/blocks/initialization.py
+++ b/blocks/initialization.py
@@ -1,8 +1,8 @@
 """Objects for encapsulating parameter initialization strategies."""
 from abc import ABCMeta, abstractmethod
+import numbers
 
 import numpy
-import six
 import theano
 from six import add_metaclass
 
@@ -209,7 +209,7 @@ class Sparse(NdarrayInitialization):
 
     def generate(self, rng, shape):
         weights = self.sparse_init.generate(rng, shape)
-        if isinstance(self.num_init, six.integer_types):
+        if isinstance(self.num_init, numbers.Integral):
             if not self.num_init > 0:
                 raise ValueError
             num_init = self.num_init

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -78,7 +78,7 @@ That is, avoid trivial checks such as
 
 .. code-block:: python
 
-   isinstance(var, six.integer_types)
+   isinstance(var, numbers.Integral)
    isinstance(var, (tuple, list))
 
 in cases where any number (like a float without a fractional part or a NumPy

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,5 +1,6 @@
+import numbers
+
 import numpy
-import six
 import theano
 from numpy.testing import assert_equal, assert_allclose, assert_raises
 
@@ -68,7 +69,7 @@ def test_sparse():
         assert weights.shape == shape
         assert weights.dtype == theano.config.floatX
         if sparse_init is None:
-            if isinstance(num_init, six.integer_types):
+            if isinstance(num_init, numbers.Integral):
                 assert (numpy.count_nonzero(weights) <=
                         weights.size - num_init * weights.shape[0])
             else:


### PR DESCRIPTION
Reminded by mila-udem/fuel#179. You should use `numbers.Integral` when it's absolutely necessary to check types, because it catches

* `int` and `long` on Python 2, or just `int` on Python 3
* All subclasses of `numpy.integer` (`numpy.int8`, `numpy.int16`, `numpy.int32`, `numpy.int64`, `numpy.uint8`, `numpy.uint16`, `numpy.uint32`, `numpy.uint64`) that you might get when iterating over a numpy array of integers.