### PR TITLE
added bokeh, pandas and blocks-extras to .travis.yml #739

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,16 @@ install:
   # Install all Python dependencies
   - conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl --file req-travis-conda.txt
   - pip install -q -r req-travis-pip.txt
+  - pip install -q git+git://github.com/mila-udem/blocks-extras.git 
+  - conda install -q --yes bokeh
+  - conda install -q --yes pandas
 script:
   - pip install -e . -r requirements.txt # Tests setup.py
   - curl https://raw.githubusercontent.com/mila-udem/fuel/master/.travis-data.sh | bash -s -- mnist
   - # Must export environment variable so that the subprocess is aware of it
   - export THEANO_FLAGS=floatX=$FLOATX,optimizer=fast_compile
   - export FUEL_FLOATX=$FLOATX
+  - bokeh-server & #start bokeh-server
   - "if [[ $DB == 'sqlite' ]]; then echo 'log_backend: sqlite' > ~/.blocksrc; fi"
   - # Running nose2 within coverage makes imports count towards coverage
   - function fail { export FAILED=1; }


### PR DESCRIPTION
MNIST example uses bokeh for plotting. Added bokeh, pandas and blocks-extras to .travis.yml. Also started bokeh-server. In response to https://github.com/mila-udem/blocks-examples/pull/19#issuecomment-118113170