### PR TITLE
allow the use of a subset of datasets sources

### DIFF
--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -38,6 +38,25 @@ def test_gradient_descent_with_gradients():
     assert_allclose(W.get_value(), -0.5 * W_start_value)
 
 
+def test_gradient_descent_spurious_sources():
+    W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
+    W_start_value = W.get_value()
+    cost = tensor.sum(W ** 2)
+
+    algorithm = GradientDescent(cost=cost, parameters=[W])
+    algorithm.step_rule.learning_rate.set_value(0.75)
+    algorithm.initialize()
+    assert_raises(lambda:
+                  algorithm.process_batch(dict(example_id='test')))
+
+    algorithm = GradientDescent(cost=cost, parameters=[W],
+                                on_unused_sources='ignore')
+    algorithm.step_rule.learning_rate.set_value(0.75)
+    algorithm.initialize()
+    algorithm.process_batch(dict(example_id='test'))
+    assert_allclose(W.get_value(), -0.5 * W_start_value)
+
+
 def test_basic_momentum():
     a = shared_floatx([3, 4])
     cost = (a ** 2).sum()


### PR DESCRIPTION
The GradientDescent class forces that the iterator provides exactly the same sources as those demanded by the gradient graph. 

This is too restrictive - it is enough that all sources are provided, also one may want to use e.g. an example-id source for monitoring, but not for gradient computations.