### PR TITLE
Performance

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -787,8 +787,9 @@ class RemoveNotFinite(StepRule):
         self.scaler = scaler
 
     def compute_step(self, parameter, previous_step):
-        not_finite = (tensor.isnan(previous_step).sum() +
-                      tensor.isinf(previous_step).sum())
+        step_sum = tensor.sum(previous_step)
+        not_finite = (tensor.isnan(step_sum) +
+                      tensor.isinf(step_sum))
         step = tensor.switch(
             not_finite > 0, (1 - self.scaler) * parameter, previous_step)
         return step, []

--- a/blocks/theano_expressions.py
+++ b/blocks/theano_expressions.py
@@ -14,11 +14,9 @@ def l2_norm(tensors):
         The tensors.
 
     """
-    flattened = [tensor.as_tensor_variable(t).flatten() for t in tensors]
-    flattened = [(t if t.ndim > 0 else t.dimshuffle('x'))
-                 for t in flattened]
-    joined = tensor.join(0, *flattened)
-    return tensor.sqrt(tensor.sqr(joined).sum())
+    summed = [tensor.sqr(tensor.as_tensor_variable(t)).sum() for t in tensors]
+    joined = tensor.stack(*summed)
+    return tensor.sqrt(joined.sum())
 
 
 def hessian_times_vector(gradient, parameter, vector, r_op=False):


### PR DESCRIPTION
A few speed fixes:

replace ifelse with switch (ifelse has no GPU implementation, kills performance in monitors),
prevent the creation of a large temp array in l2norm and defer the isnan/isinf check to only after the arrays are reduced in RemoveNotFinite (inf and nan will propagete with the sum anyway).

Note that Theano has a very poor reduction implementation and gradient norm monitoring. checking for nans can easily take more that gradient computation itself.