### PR TITLE
WIP: New Serialization

### DIFF
--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -1,9 +1,129 @@
+"""Blocks native serialization - tar files with pickles and numpy arrays.
+
+This module provides :func:`load` and :func:`dump` functions that can serve
+as drop-in replacement for the respective functions from the standard
+:mod:`pickle` module. The main differences between them and the standard
+ones are:
+
+    - The dump is physically a tarball, in which the pickle is stored
+      as 'pkl' file.
+
+    - Parts of the dumped object can be pickled separately but be
+      referenced from 'pkl' file using the persisent id mechanism (see
+      :mod:`pickle`) docs. Such parts are stored as arbitrarily named files
+      in the tarball. The benefit is that when unpickling 'pkl' breaks for
+      some reason (typically because of changes in the codebase used), one
+      can still have access to certain parts of the dumped object.
+
+    - A special file 'parameters' in the tarball can contain the data
+      of a selected set of Theano shared variables. Again, this data is
+      referenced from `pkl` using persistent id mechanism, which means that
+      no duplication takes place. The goal here is to save the values of
+      the parameters (this is what these shared variables are in most
+      cases) in the most robust way possible. The actual format for
+      'parameters' file is the one used by :func:`numpy.savez`, i.e.  a zip
+      file of numpy arrays.
+
+    - The :func:`dump` strives to catch situations when the user tries
+      to pickle a function or a class not defined in the global namespace
+      and give a meaningful warning.
+
+If briefly, this module proposes a dumping mechanism which allows for
+greater robustness and persistency than standard pickling.
+
+Examples
+--------
+
+Consider a standard main loop (without an algorithm and a data stream
+for brevity)
+
+>>> from theano import tensor
+>>> from blocks.main_loop import MainLoop
+>>> from blocks.bricks import MLP, Tanh, Softmax
+>>> from blocks.model import Model
+>>> mlp = MLP([Tanh(), None], [784, 10, 10])
+>>> x = tensor.matrix('features')
+>>> y = tensor.lmatrix('targets')
+>>> cost = Softmax().categorical_cross_entropy(
+...            y.flatten(), mlp.apply(tensor.flatten(x, outdim=2)))
+>>> main_loop = MainLoop(None, None, model=Model(cost))
+
+Let's see how the main loop is dumped by :func:`dump`
+
+>>> from blocks.serialization import dump, load
+>>> import tarfile
+>>> with open('main_loop.tar', 'w') as dst:
+...     dump(main_loop, dst)
+>>> tarball = tarfile.open('main_loop.tar', 'r')
+>>> tarball # doctest: +ELLIPSIS
+<tarfile.TarFile object at ...>
+>>> tarball.getnames()
+['pkl']
+>>> tarball.close()
+
+As promised, the dump is a tarball. Since we did not ask for any additional
+magic, it just contains the pickled main loop in 'pkl' file.
+
+Let's do something more interesting:
+
+>>> with open('main_loop.tar', 'w') as dst:
+...     dump(main_loop, dst,
+...          pickle_separately=[(main_loop.log, 'log')],
+...          parameters=main_loop.model.parameters)
+>>> tarball = tarfile.open('main_loop.tar', 'r')
+>>> tarball.getnames()
+['parameters', 'log', 'pkl']
+
+As requested by specifying `pickle_separately` and `parameters` arguments,
+the log was pickled separately and the parameters were saved in a zip file.
+
+>>> import numpy
+>>> ps = numpy.load(tarball.extractfile(tarball.getmember('parameters')))
+>>> sorted(ps.keys()) # doctest: +ELLIPSIS
+['|mlp|linear_0.W', '|mlp|linear_0.b', '|mlp|linear_1.W', '|mlp|lin...]
+>>> ps.close()
+
+The names for parameters are chosen intellegently to reflect their
+position in the brick hierarchy, if they belong to bricks, and by
+simpling using the `.name` attribute, if they do not.
+
+>>> import pickle
+>>> pickle.load(tarball.extractfile(tarball.getmember('log')))
+defaultdict(<type 'dict'>, {})
+>>> tarball.close()
+
+The loading of the main loop as a whole however still works:
+
+>>> with open('main_loop.tar') as src:
+...     main_loop_loaded = load(src)
+>>> main_loop_loaded # doctest: +ELLIPSIS
+<blocks.main_loop.MainLoop object at ...>
+
+Additionally, this module provides convenience routines
+:func:`load_part` and :func:`load_parameters`:
+
+>>> with open('main_loop.tar') as src:
+...     parameters = load_parameters(src)
+>>> with open('main_loop.tar') as src:
+...     log = load_part(src, 'log')
+>>> log
+defaultdict(<type 'dict'>, {})
+>>> sorted(parameters.keys()) # doctest: +ELLIPSIS
+['/mlp/linear_0.W', '/mlp/linear_0.b', '/mlp/linear_1.W', '/mlp/line...]
+
+Loading parameters saved by :func:`dump` with :func:`load_parameters`
+ensures that their heirarchical names are compatible with
+:class:`~blocks.model.Model` and :class:`~blocks.select.Selector` classes.
+
+"""
 import os
 import shutil
 import six
 import tempfile
 import warnings
+import tarfile
 import zipfile
+import pickle
 from contextlib import closing
 from pickle import HIGHEST_PROTOCOL
 try:
@@ -12,20 +132,22 @@ try:
 except ImportError:
     DEFAULT_PROTOCOL = HIGHEST_PROTOCOL
     from pickle import Pickler as _Pickler
-
+try:
+    from theano.sandbox.cuda import cuda_ndarray
+except ImportError:
+    cuda_ndarray = None
 import numpy
 from six.moves import cPickle
 from theano.compile.sharedvalue import SharedVariable
 from theano.misc import pkl_utils
-from theano.misc.pkl_utils import (PersistentCudaNdarrayID,
-                                   PersistentSharedVariableID)
+from theano.misc.pkl_utils import zipadd
 
 from blocks.config import config
 from blocks.filter import get_brick
 from blocks.utils import change_recursion_limit
 
 
-BRICK_DELIMITER = '-'
+BRICK_DELIMITER = '|'
 MAIN_MODULE_WARNING = """WARNING: Main loop depends on the function `{}` in \
 `__main__` namespace.
 
@@ -34,130 +156,108 @@ resume your model outside of a namespace containing this function. In other \
 words, you can only call `continue_training` from within this script."""
 
 
-class PersistentParameterID(PersistentSharedVariableID):
-    """Persist the names of parameter arrays in the zip file.
-
-    Only Theano shared variables are persisted to the zip file using this
-    method. Names are determined using the brick hierarchy, or the shared
-    variable name.
-
-    Parameters
-    ----------
-    allow_unnamed : bool, optional
-        Allow shared variables without a name to be persisted. Defaults to
-        ``True``.
-    allow_duplicates : bool, optional
-        Allow multiple shared variables to have the same name, in which
-        case they will be numbered e.g. `x`, `x_2`, `x_3`, etc. Defaults to
-        ``True``.
-
-    Raises
-    ------
-    ValueError
-        If an unnamed shared variable is encountered and `allow_unnamed` is
-        ``False``, or if two shared variables have the same name, and
-        `allow_duplicates` is ``False``.
-
-    """
-    def __call__(self, obj):
-        if isinstance(obj, SharedVariable):
-            super(PersistentParameterID, self).__call__(obj)
-            if hasattr(obj.tag, 'annotations'):
-                name = '{}.{}'.format(
-                    BRICK_DELIMITER.join([brick.name for brick in
-                                          get_brick(obj).get_unique_path()]),
-                    obj.name
-                )
-            else:
-                name = obj.name
-            self.ndarray_names[id(obj.container.storage[0])] = name
-        if id(obj) in self.ndarray_names:
-            PersistentCudaNdarrayID.__call__(self, obj)
+_ARRAY_TYPE_MAP = {numpy.ndarray : 'numpy_ndarray'}
+if cuda_ndarray:
+    _ARRAY_TYPE_MAP[cuda_ndarray.cuda_ndarray.CudaNdarray] = 'cuda_ndarray'
+_INVERSE_ARRAY_TYPE_MAP = {value: key
+                           for key, value in _ARRAY_TYPE_MAP.items()}
 
 
-class PicklerWithWarning(_Pickler):
-    dispatch = _Pickler.dispatch.copy()
-
-    def save_global(self, obj, name=None, **kwargs):
-        module = getattr(obj, '__module__', None)
-        if module == '__main__':
-            warnings.warn(
-                MAIN_MODULE_WARNING.format(kwargs.get('name', obj.__name__))
-            )
-        _Pickler.save_global(self, obj, name=name, **kwargs)
-
-    dispatch[six.types.FunctionType] = save_global
-    if six.PY2:
-        dispatch[six.types.ClassType] = save_global
-        dispatch[six.types.BuiltinFunctionType] = save_global
-        dispatch[six.types.TypeType] = save_global
+def taradd(func, tar_file, name):
+    with tempfile.NamedTemporaryFile('wb', delete=False) as temp_file:
+        func(temp_file)
+        temp_file.close()
+        tar_file.add(temp_file.name, arcname=name)
+    if os.path.isfile(temp_file.name):
+        os.remove(temp_file.name)
 
 
-def dump(obj, file_handler, protocol=DEFAULT_PROTOCOL,
-         persistent_id=PersistentParameterID, use_cpickle=False):
-    """Pickles an object to a zip file using external persistence.
+def _mangle_parameter_name(type_, name):
+    return '#{}.{}'.format(_ARRAY_TYPE_MAP[type_], name)
+
+
+def _unmangle_parameter_name(mangled_name):
+    if mangled_name.startswith('#'):
+        type_, name = mangled_name[1:].split('.', 1)
+        return _INVERSE_ARRAY_TYPE_MAP[type_], name
+
+
+class Renamer(object):
+    def __init__(self):
+        self.used_names = set()
+    def __call__(self, parameter):
+        # TODO: handle usual shared variables
+        # TODO: handle shared variables without names
+        # TODO: handle duplicates
+        name = '{}.{}'.format(
+            BRICK_DELIMITER.join(
+                [""] + [brick.name for brick in
+                        get_brick(parameter).get_unique_path()]),
+            parameter.name)
+        return name
+
+
+class PersistentID(object):
+    """Returns persistent identifiers for objects saved separately."""
+    def __init__(self, external_objects):
+        self.external_objects = external_objects
+
+    def __call__(self, object_):
+        return self.external_objects.get(id(object_))
+
+
+def dump(object_, file_,
+         parameters=None, pickle_separately=None,
+         dont_pickle_whole=False, use_cpickle=True, **kwargs):
+    """Pickles an object saving some of its parts separately.
 
     Parameters
     ----------
-    obj : object
-        The object to pickle.
-    file_handler : file
-        The file handle to save the object to.
-    protocol : int, optional
-        The pickling protocol to use. Unlike Python's built-in pickle, the
-        default is set to `2` instead of 0 for Python 2. The Python 3
-        default (level 3) is maintained.
-    persistent_id : callable
-        The callable that persists certain objects in the object hierarchy
-        to separate files inside of the zip file. For example,
-        :class:`PersistentNdarrayID` saves any :class:`numpy.ndarray` to a
-        separate NPY file inside of the zip file.
-    use_cpickle : bool
-        This enables the use of C-version of `pickle` (known as ``cPickle``
-        in Python 2). Note that this disables warnings about trying to
-        pickle objects in the ``__main__`` namespace.
-
-    Notes
-    -----
-    The final file is simply a zipped file containing at least one file,
-    `pkl`, which contains the pickled object. It can contain any other
-    number of external objects. Note that the zip files are compatible with
-    NumPy's :func:`numpy.load` function.
-
-    >>> import numpy
-    >>> from blocks.bricks import MLP, Identity
-    >>> from blocks.initialization import Constant
-    >>> mlp = MLP([Identity()], [10, 10], weights_init=Constant(0.),
-    ...           biases_init=Constant(0.))
-    >>> mlp.initialize()
-    >>> with open('model.zip', 'wb') as f:
-    ...     dump(mlp, f)
-    >>> 'mlp-linear_0.W' in numpy.load('model.zip').keys()
-    True
-    >>> 'mlp-linear_0.b' in numpy.load('model.zip').keys()
-    True
-    >>> numpy.load('model.zip')['mlp-linear_0.W'].shape
-    (10, 10)
-    >>> with open('model.zip', 'rb') as f:
-    ...     mlp2 = load(f)
-    >>> mlp2  # doctest: +ELLIPSIS
-    <blocks.bricks.MLP object at ...: name=mlp>
+    object_ : object
+        The object to be pickled.
+    file_ : file
+        The destination for saving.
+    parameters : list, optional
+        Shared variables whose internal numpy arrays should be saved
+        separately in the `parameters` field of the zip file.
+    pickle_separately : dict, optional
+        Specifies the components of `object_` that should be pickled
+        separately. The keys are the objects, the values will be used
+        to form persistent ids and as field names in the resulting zip
+        file.
+    dont_pickle_whole : bool, optional
+        When ``False``, the whole object is not pickled, only its
+        components are.
 
     """
-    with closing(zipfile.ZipFile(file_handler, 'w', zipfile.ZIP_DEFLATED,
-                                 allowZip64=True)) as zip_file:
-        def func(f):
-            if use_cpickle:
-                p = cPickle.Pickler(f, protocol=protocol)
-            else:
-                p = PicklerWithWarning(f, protocol=protocol)
-            p.persistent_id = persistent_id(zip_file)
-            p.dump(obj)
-        pkl_utils.zipadd(func, zip_file, 'pkl')
+    if not pickle_separately:
+        pickle_separately = []
+    # TODO: check name collision with 'pkl' and 'parameters'
+    with closing(tarfile.TarFile(fileobj=file_, mode='w')) as tar_file:
+        external_objects = {}
+        def save_parameters(f):
+            # TODO: how exactly should get_value be called?
+            renamer = Renamer()
+            named_parameters = {renamer(p): p for p in parameters}
+            numpy.savez(f, **{name : p.get_value()
+                              for name, p in named_parameters.items()})
 
-
-# A thin wrapper around Theano load.
-load = pkl_utils.load
+            for name, p in named_parameters.items():
+                array_ = p.container.storage[0]
+                external_objects[id(array_)] = _mangle_parameter_name(
+                    type(array_), name)
+        if parameters:
+            taradd(save_parameters, tar_file, 'parameters')
+        if pickle_separately:
+            for component, name in pickle_separately:
+                def pickle_separately(f):
+                    pickle.dump(component, f)
+                taradd(pickle_separately, tar_file, name)
+        def pickle_whole(f):
+            p = pickle.Pickler(f, **kwargs)
+            p.persistent_id = PersistentID(external_objects)
+            p.dump(object_)
+        taradd(pickle_whole, tar_file, 'pkl')
 
 
 def secure_dump(object_, path, dump_function=dump, **kwargs):
@@ -185,6 +285,61 @@ def secure_dump(object_, path, dump_function=dump, **kwargs):
         if "temp" in locals():
             os.remove(temp.name)
         raise
+
+
+class PersistentLoad(object):
+    def __init__(self, tar_file):
+        self.tar_file = tar_file
+        self.parameters = numpy.load(
+            tar_file.extractfile(tar_file.getmember('parameters')))
+    def __call__(self, id_):
+        components = _unmangle_parameter_name(id_)
+        if not components:
+            return pickle.load(
+                self.tar_file.extractfile(self.tar_file.getmember(id_)))
+        else:
+            # TODO: support CUDA
+            return self.parameters[components[1]]
+
+
+def load(file_):
+    with tarfile.open(fileobj=file_, mode='r') as tar_file:
+        p = pickle.Unpickler(
+            tar_file.extractfile(tar_file.getmember('pkl')))
+        p.persistent_load = PersistentLoad(tar_file)
+        return p.load()
+
+
+def load_part(file_, part):
+    with tarfile.open(fileobj=file_, mode='r') as tar_file:
+        return pickle.load(tar_file.extractfile(tar_file.getmember(part)))
+
+
+def load_parameters_npzfile(file_):
+    with tarfile.TarFile(fileobj=file_, mode='r') as tar_file:
+        return numpy.load(
+            tar_file.extractfile(tar_file.getmember('parameters')))
+
+
+def load_parameters(file_):
+    """Load parameter values saved by :func:`dump`.
+
+    This is a thin wrapper over :func:`numpy.load`. It changes the names of
+    the arrays to ones compatible with :meth:`.Model.set_param_values`.
+
+    Parameters
+    ----------
+    path : str or file
+        The source for loading from.
+
+    Returns
+    -------
+    A dictionary of (parameter name, numpy array) pairs.
+
+    """
+    with closing(load_parameters_npzfile(file_)) as npz_file:
+        return {name.replace(BRICK_DELIMITER, '/'): value
+                for name, value in npz_file.items()}
 
 
 def continue_training(path):
@@ -218,25 +373,3 @@ def continue_training(path):
         with open(path, "rb") as f:
             main_loop = load(f)
     main_loop.run()
-
-
-def load_parameter_values(path):
-    """Load parameter values saved by :func:`dump`.
-
-    This is a thin wrapper over :func:`numpy.load`. It changes the names of
-    the arrays to ones compatible with :meth:`.Model.set_param_values`.
-
-    Parameters
-    ----------
-    path : str or file
-        The source for loading from.
-
-    Returns
-    -------
-    A dictionary of (parameter name, numpy array) pairs.
-
-    """
-    with closing(numpy.load(path)) as source:
-        param_values = {'/' + name.replace(BRICK_DELIMITER, '/'): value
-                        for name, value in source.items() if name != 'pkl'}
-    return param_values

--- a/docs/api/serialization.rst
+++ b/docs/api/serialization.rst
@@ -1,0 +1,7 @@
+Serialization
+=============
+
+.. automodule:: blocks.serialization
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/development/internal_api.rst
+++ b/docs/development/internal_api.rst
@@ -46,9 +46,3 @@ Utils
    :members:
    :private-members:
    :show-inheritance:
-
-.. automodule:: blocks.serialization
-   :undoc-members:
-   :members:
-   :private-members:
-   :show-inheritance:


### PR DESCRIPTION
The current serialization used in Blocks has the following shortcomings:

- although the parameters are indeed saved robustly as numpy arrays, they are contained in a zip file with a lot of rubbish, which makes it in practice not possible to fetch them

- only parameters are saved as additional fields in the dump, for all the rest one can only use `save_separately` which is less convenient, since it produces separate files, #746 

- if main loop is itself not picklable, nothing will be saved, #758 

This PR proposes a new serialization, which does not have these issues. It is so far only a working draft, but I put some effort into docstring of the new `blocks/serialization.py` module and kindly invite you to read it and tell, if you like it and if you think that this PR should be finished and merged.

TODO:
- [ ]  documentation is missing for many functions
- [ ] handle usual shared variables (not created by bricks)
- [ ]  handle shared variables without names
- [ ]  handle variables with duplicate names 
- [ ]  support CUDA