### PR TITLE
A change to DifferentiableCostMinimizer.__init__ had broken the tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -180,7 +180,7 @@ The training algorithm we will use is straightforward SGD with a fixed
 learning rate.
 
 >>> from blocks.algorithms import GradientDescent, Scale
->>> algorithm = GradientDescent(cost=cost, parameters=cg.parameters,
+>>> algorithm = GradientDescent(cost=cost, params=cg.parameters,
 ...                             step_rule=Scale(learning_rate=0.1))
 
 During training we will want to monitor the performance of our model on


### PR DESCRIPTION
DifferentiableCostMinimizer.__init__'s signature is DifferentiableCostMinimizer.__init__(self, cost, params), not DifferentiableCostMinimizer.(self, cost, parameters) anymore, breaking the tutorial.