### PR TITLE
Fix Parallel.apply routing logic.

### DIFF
--- a/blocks/bricks/parallel.py
+++ b/blocks/bricks/parallel.py
@@ -5,7 +5,7 @@ from picklable_itertools.extras import equizip
 
 from blocks.bricks import Initializable, Linear
 from blocks.bricks.base import lazy, application
-from blocks.utils import pack
+from blocks.utils import pack, extract_args
 
 
 class Parallel(Initializable):
@@ -82,21 +82,7 @@ class Parallel(Initializable):
 
     @application
     def apply(self, *args, **kwargs):
-        # Use of zip() rather than equizip() intentional here.
-        routed_args = dict(zip(self.input_names, args))
-        for name in kwargs:
-            if name not in self.input_names:
-                raise KeyError('invalid input name: {}'.format(name))
-            elif name in routed_args:
-                raise TypeError("{}.apply got multiple values for "
-                                "argument '{}'".format(self.__class__.__name__,
-                                                       name))
-            else:
-                routed_args[name] = kwargs[name]
-        if set(self.input_names) != set(routed_args):
-            raise ValueError('missing values for inputs: {}'.format(
-                             [name for name in self.input_names
-                              if name not in routed_args]))
+        routed_args = extract_args(self.input_names, *args, **kwargs)
         return [child.apply(routed_args[name])
                 for name, child in equizip(self.input_names, self.children)]
 

--- a/blocks/utils/__init__.py
+++ b/blocks/utils/__init__.py
@@ -487,9 +487,9 @@ def extract_args(expected, *args, **kwargs):
 
     Returns
     -------
-    routed_args : dict
-        A dictionary mapping the names in `expected` to values drawn
-        from either `args` or `kwargs`.
+    routed_args : OrderedDict
+        An OrderedDict mapping the names in `expected` to values drawn
+        from either `args` or `kwargs` in the usual Python fashion.
 
     Raises
     ------
@@ -519,4 +519,4 @@ def extract_args(expected, *args, **kwargs):
         raise ValueError('missing values for inputs: {}'.format(
                          [name for name in expected
                           if name not in routed_args]))
-    return routed_args
+    return OrderedDict((key, routed_args[key]) for key in expected)

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -7,7 +7,7 @@ from theano import tensor
 from blocks.bricks import (Identity, Linear, Maxout, LinearMaxout, MLP, Tanh,
                            Sequence, Random, Logistic, Softplus, Softmax)
 from blocks.bricks.base import application, Brick, lazy, NoneAllocation
-from blocks.bricks.parallel import Parallel, Fork, Merge
+from blocks.bricks.parallel import Parallel, Fork
 from blocks.filter import get_application_call, get_brick
 from blocks.initialization import Constant
 from blocks.utils import shared_floatx
@@ -443,32 +443,6 @@ def test_sequence_variable_inputs():
         new_y.eval({y: y_val}),
         (y_val.dot(2 * numpy.ones((5, 2))) + numpy.ones((4, 2))).dot(
             2 * numpy.ones((2, 4))) + numpy.ones((4, 4)))
-
-
-def test_parallel_arguments():
-    brick = Merge(['x', 'y', 'z'], [9, 2, 4], 5)
-    x, y, z = tensor.matrix(), tensor.matrix(), tensor.matrix()
-
-    def assert_no_exceptions(f, *args, **kwargs):
-        try:
-            f(*args, **kwargs)
-        except Exception as e:
-            raise
-            assert False, "exception raised: {}: {}".format(type(e), e)
-
-    assert_no_exceptions(brick.apply, x, y, z)
-    assert_no_exceptions(brick.apply, x, y, z=z)
-    assert_no_exceptions(brick.apply, x, y=y, z=z)
-    assert_no_exceptions(brick.apply, x=x, y=y, z=z)
-    assert_raises(KeyError, brick.apply, x, y, zzz=z)
-    assert_raises(KeyError, brick.apply, x, y, z=z, zzz=z)
-    assert_raises(TypeError, brick.apply, x, y, y=y)
-    assert_raises(TypeError, brick.apply, x, y, y=y, z=z)
-    assert_raises(ValueError, brick.apply, x, y)
-    assert_raises(ValueError, brick.apply, x, y=y)
-    assert_raises(ValueError, brick.apply, x=x, y=y)
-    assert_raises(ValueError, brick.apply, x=x)
-    assert_raises(ValueError, brick.apply, x)
 
 
 def test_application_call():


### PR DESCRIPTION
Fixes #812.

Basically, the way we handle `*args` and `**kwargs` in Parallel.apply is broken. It essentially forces you to use kwargs. It seems like the `*args` was hastily added to make a test pass or something.

The correct thing to do is treat the `*args` as the inputs for the first `len(args)` things in `self.input_names` and then try to fill the rest with `**kwargs`. If a keyword is there that doesn't match anything in `self.input_names`, we should say so. If we get the same input specified as a positional and keyword argument, we should make like Python does:

```
>>> def foo(a, **kwargs):
...     pass
...
>>> foo(5, a=3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: foo() got multiple values for argument 'a'
```

If after accounting for all `*args` and `**kwargs`, we are missing inputs for some child bricks, we should say so.

@vdumoulin You were the last one to edit this line, could you look at my change?