### PR TITLE
Elaborate LSTM inputs argument to apply method

### DIFF
--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -442,8 +442,8 @@ class LSTM(BaseRecurrent, Initializable):
             A 1D binary array in the shape (batch,) which is 1 if there is
             data available, 0 if not. Assumed to be 1-s only if not given.
 
-        .. [Grav13] Graves, Alex, *Generating sequences with recurrent neural
-            networks*, arXiv preprint arXiv:1308.0850 (2013).
+        .. [Grav13] Graves, Alex, *Generating sequences with recurrent
+            neural networks*, arXiv preprint arXiv:1308.0850 (2013).
 
         Returns
         -------

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -434,10 +434,16 @@ class LSTM(BaseRecurrent, Initializable):
             (batch_size, features). Required for `one_step` usage.
         inputs : :class:`~tensor.TensorVariable`
             The 2 dimensional matrix of inputs in the shape (batch_size,
-            features * 4).
+            features * 4). The `inputs` needs to be four times the dimension of
+            the LSTM brick to insure each four gates receive different
+            transformations of the input. See [Grav13]_ equations 7 to 10 for
+            more details.
         mask : :class:`~tensor.TensorVariable`
             A 1D binary array in the shape (batch,) which is 1 if there is
             data available, 0 if not. Assumed to be 1-s only if not given.
+
+        .. [Grav13] Graves, Alex, *Generating sequences with recurrent neural
+            networks*, arXiv preprint arXiv:1308.0850 (2013).
 
         Returns
         -------

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -434,10 +434,10 @@ class LSTM(BaseRecurrent, Initializable):
             (batch_size, features). Required for `one_step` usage.
         inputs : :class:`~tensor.TensorVariable`
             The 2 dimensional matrix of inputs in the shape (batch_size,
-            features * 4). The `inputs` needs to be four times the dimension of
-            the LSTM brick to insure each four gates receive different
-            transformations of the input. See [Grav13]_ equations 7 to 10 for
-            more details.
+            features * 4). The `inputs` needs to be four times the
+            dimension of the LSTM brick to insure each four gates receive
+            different transformations of the input. See [Grav13]_
+            equations 7 to 10 for more details.
         mask : :class:`~tensor.TensorVariable`
             A 1D binary array in the shape (batch,) which is 1 if there is
             data available, 0 if not. Assumed to be 1-s only if not given.


### PR DESCRIPTION
Since I lost an hour trying to understand why the inputs should be 4 times as large as the output and because my first thought was to tile the inputs, I made this small addition to the docs of the LSTM `apply` method.