### PR TITLE
Add role and names to algorithm shared variables

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -12,8 +12,9 @@ from six import add_metaclass
 from theano import tensor
 
 from blocks.graph import ComputationGraph
-from blocks.utils import dict_subset, named_copy, pack, shared_floatx
+from blocks.roles import add_role, ALGORITHM_HYPERPARAMETER, ALGORITHM_BUFFER
 from blocks.theano_expressions import l2_norm
+from blocks.utils import dict_subset, named_copy, pack, shared_floatx
 
 logger = logging.getLogger(__name__)
 
@@ -392,7 +393,8 @@ class Scale(StepRule):
 
     """
     def __init__(self, learning_rate=1.0):
-        self.learning_rate = shared_floatx(learning_rate)
+        self.learning_rate = shared_floatx(learning_rate, "learning_rate")
+        add_role(self.learning_rate, ALGORITHM_HYPERPARAMETER)
 
     def compute_step(self, parameter, previous_step):
         return self.learning_rate * previous_step, []
@@ -414,10 +416,12 @@ class BasicMomentum(StepRule):
 
     """
     def __init__(self, momentum=0.):
-        self.momentum = shared_floatx(momentum)
+        self.momentum = shared_floatx(momentum, "momentum")
+        add_role(self.momentum, ALGORITHM_HYPERPARAMETER)
 
     def compute_step(self, parameter, previous_step):
-        velocity = shared_floatx(parameter.get_value() * 0.)
+        velocity = shared_floatx(parameter.get_value() * 0., "velocity")
+        add_role(velocity, ALGORITHM_BUFFER)
         step = self.momentum * velocity + previous_step
         updates = [(velocity, step)]
         return step, updates
@@ -477,12 +481,18 @@ class AdaDelta(StepRule):
     def __init__(self, decay_rate=0.95, epsilon=1e-6):
         if not 0.0 <= decay_rate <= 1.0:
             raise ValueError("decay rate needs to be in [0, 1]")
-        self.decay_rate = shared_floatx(decay_rate)
-        self.epsilon = shared_floatx(epsilon)
+        self.decay_rate = shared_floatx(decay_rate, "decay_rate")
+        add_role(self.decay_rate, ALGORITHM_HYPERPARAMETER)
+        self.epsilon = shared_floatx(epsilon, "epsilon")
+        add_role(self.epsilon, ALGORITHM_HYPERPARAMETER)
 
     def compute_step(self, parameter, previous_step):
-        mean_square_step_tm1 = shared_floatx(parameter.get_value() * 0.)
-        mean_square_delta_x_tm1 = shared_floatx(parameter.get_value() * 0.)
+        mean_square_step_tm1 = shared_floatx(parameter.get_value() * 0.,
+                                             "mean_square_step_tm1")
+        add_role(mean_square_step_tm1, ALGORITHM_BUFFER)
+        mean_square_delta_x_tm1 = shared_floatx(parameter.get_value() * 0.,
+                                                "mean_square_delta_x_tm1")
+        add_role(mean_square_delta_x_tm1, ALGORITHM_BUFFER)
 
         mean_square_step_t = (
             self.decay_rate * mean_square_step_tm1 +
@@ -535,14 +545,18 @@ class BasicRMSProp(StepRule):
             raise ValueError("decay rate needs to be in [0, 1]")
         if max_scaling <= 0:
             raise ValueError("max. scaling needs to be greater than 0")
-        self.decay_rate = shared_floatx(decay_rate)
+        self.decay_rate = shared_floatx(decay_rate, "decay_rate")
+        add_role(self.decay_rate, ALGORITHM_HYPERPARAMETER)
         self.epsilon = 1. / max_scaling
 
     def compute_step(self, parameter, previous_step):
-        mean_square_step_tm1 = shared_floatx(parameter.get_value() * 0.)
+        mean_square_step_tm1 = shared_floatx(parameter.get_value() * 0.,
+                                             "mean_square_step_tm1")
+        add_role(mean_square_step_tm1, ALGORITHM_BUFFER)
         mean_square_step_t = (
             self.decay_rate * mean_square_step_tm1 +
             (1 - self.decay_rate) * tensor.sqr(previous_step))
+        add_role(mean_square_step_t, ALGORITHM_BUFFER)
         rms_step_t = tensor.maximum(
             tensor.sqrt(mean_square_step_t), self.epsilon)
         step = previous_step / rms_step_t
@@ -613,7 +627,8 @@ class StepClipping(StepRule):
     """
     def __init__(self, threshold=None):
         if threshold:
-            self.threshold = shared_floatx(threshold)
+            self.threshold = shared_floatx(threshold, "threshold")
+            add_role(self.threshold, ALGORITHM_HYPERPARAMETER)
 
     def compute_steps(self, previous_steps):
         if not hasattr(self, 'threshold'):
@@ -677,7 +692,8 @@ class VariableClipping(StepRule):
     def __init__(self, threshold, axis=None):
         axis = pack(axis) if axis is not None else ()
         self.axis = set(axis)
-        self.threshold = shared_floatx(threshold)
+        self.threshold = shared_floatx(threshold, "threshold")
+        add_role(self.threshold, ALGORITHM_HYPERPARAMETER)
         if len(axis) != len(self.axis):
             raise ValueError("axis must be unique")
 
@@ -735,6 +751,7 @@ class AdaGrad(StepRule):
             name += '_' + parameter.name
         ssq = shared_floatx(parameter.get_value() * 0.,
                             name=name)
+        add_role(ssq, ALGORITHM_BUFFER)
 
         ssq_t = (tensor.sqr(previous_step) + ssq)
         step = (self.learning_rate * previous_step /
@@ -780,8 +797,11 @@ class Adam(StepRule):
 
     def compute_step(self, parameter, previous_step):
         mean = shared_floatx(parameter.get_value() * 0., 'mean')
+        add_role(mean, ALGORITHM_BUFFER)
         variance = shared_floatx(parameter.get_value() * 0., 'variance')
+        add_role(variance, ALGORITHM_BUFFER)
         time = shared_floatx(0., 'time')
+        add_role(time, ALGORITHM_BUFFER)
 
         t1 = time + 1
         learning_rate = (self.learning_rate *

--- a/blocks/roles.py
+++ b/blocks/roles.py
@@ -154,3 +154,24 @@ class CollectorRole(ParameterRole):
 
 #: A collection of parameters combined into a single shared variable
 COLLECTOR = CollectorRole()
+
+
+class AlgorithmStateRole(VariableRole):
+    pass
+
+#: Shared variables used in algorithms updates
+ALGORITHM_STATE = AlgorithmStateRole()
+
+
+class AlgorithmHyperparameterRole(AlgorithmStateRole):
+    pass
+
+#: hyperparameters accociated with algorithms
+ALGORITHM_HYPERPARAMETER = AlgorithmHyperparameterRole()
+
+
+class AlgorithmBufferRole(AlgorithmStateRole):
+    pass
+
+#: buffers accociated with algorithms
+ALGORITHM_BUFFER = AlgorithmBufferRole()


### PR DESCRIPTION
Currently blocks strives to annotate the computation graph with names and roles for useful variables. The algorithms code does not seem to do any of this. This pull request adds an `AlgorithmStateRole` and annotates algorithm's shared variables with it. I am not sold on the name AlgorithmState, if others have a better suggestion I am all ears.

My motivation for this is I wanted to access these and it proved vary difficult to do in a generic way. I would have to construct a `ComputationGraph` of the steps and somehow get the correct shared variables. Now one can use a `VariableFilter`

Let me know if this is something that would be good to add, if not I will close.

Thanks!