### PR TITLE
Update tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -180,7 +180,7 @@ The training algorithm we will use is straightforward SGD with a fixed
 learning rate.
 
 >>> from blocks.algorithms import GradientDescent, Scale
->>> algorithm = GradientDescent(cost=cost, parameters=cg.parameters,
+>>> algorithm = GradientDescent(cost=cost, params=cg.parameters,
 ...                             step_rule=Scale(learning_rate=0.1))
 
 During training we will want to monitor the performance of our model on


### PR DESCRIPTION
keyword argument `parameters` is giving the following error, which is fixed if the keyword argument is changed to `params`

```
Traceback (most recent call last):
  File "mnist_training.py", line 44, in <module>
    algorithm = GradientDescent(cost=cost, parameters=cg.parameters, step_rule=Scale(learning_rate=0.1))
  File "/usr/local/lib/python2.7/dist-packages/blocks/algorithms/__init__.py", line 193, in __init__
    super(GradientDescent, self).__init__(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'parameters'
```