### PR TITLE
Refactor model and write a bit of documentation

### DIFF
--- a/blocks/model.py
+++ b/blocks/model.py
@@ -40,11 +40,12 @@ class Model(ComputationGraph):
     >>> y = mlp.apply(x)
     >>> model = Model(y)
 
-    With :class:`Model` you can get access to the brick hierarchy. The brick
-    hierarchy is defined by ``children`` attributes that every brick has.
-    The bricks that are not children of other bricks are called top bricks.
-    It is often useful to have access to top bricks of a brick hierarchy
-    used to build a computation graph, and here is how you can do it:
+    With :class:`Model` you can get access to the brick hierarchy. The
+    brick hierarchy is defined by ``children`` attributes that every brick
+    has.  The bricks that are not children of other bricks are called top
+    bricks.  It is often useful to have access to top bricks of a brick
+    hierarchy used to build a computation graph, and here is how you can do
+    it:
 
     >>> model.get_top_bricks() #doctest: +ELLIPSIS
     [<blocks.bricks.MLP object at ...]

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -19,8 +19,6 @@ import logging
 from collections import OrderedDict, Counter
 from itertools import chain
 
-import six
-
 from blocks.graph import ComputationGraph
 from blocks.select import Selector
 from blocks.filter import get_brick

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -19,6 +19,8 @@ import logging
 from collections import OrderedDict, Counter
 from itertools import chain
 
+import six
+
 from blocks.graph import ComputationGraph
 from blocks.select import Selector
 from blocks.filter import get_brick
@@ -60,6 +62,7 @@ class Model(ComputationGraph):
 
     """
     def __init__(self, *args, **kwargs):
+        super(Model, self).__init__(*args, **kwargs)
         bricks = [get_brick(var) for var
                   in self.variables + self.scan_variables if get_brick(var)]
         children = set(chain(*(brick.children for brick in bricks)))
@@ -75,8 +78,8 @@ class Model(ComputationGraph):
             raise ValueError("top bricks with the same name:"
                              " {}".format(', '.join(repeated_names)))
         brick_parameter_names = {
-            v: k for k, v in Selector(
-                self.top_bricks).get_parameters().items()}
+            v: k for k, v in six.iteritems(Selector(
+                self.top_bricks).get_parameters())}
         parameter_list = []
         for parameter in self.parameters:
             if parameter in brick_parameter_names:

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -6,8 +6,11 @@ which is able to handle annotations and roles in general, but is
 deliberately made unaware of specific annotations that a Theano graph
 created by Blocks typically has, such as bricks and application calls.  The
 :class:`Model` adds this functionality. Using :class:`Model` you can do
-things like quering all the bricks used to build the computation graph,
-requesting "hierarhical names" of the parameters, etc.
+things like query all the bricks used to build the computation graph,
+request "hierarhical names" of the parameters (a hierarchical name is a
+path-like string which in addition to the parameter's name contains names
+of the bricks on the path from a root brick to the brick that owns the
+parameters, e.g. ``/mlp/linear/W``).
 
 For more information, see :class:`Model` docstring.
 
@@ -36,12 +39,20 @@ class Model(ComputationGraph):
     >>> mlp = MLP([Tanh(), Tanh()], [10, 10, 10])
     >>> y = mlp.apply(x)
     >>> model = Model(y)
-    >>> # With model you can get access to the brick hierarchy
+
+    With :class:`Model` you can get access to the brick hierarchy. The brick
+    hierarchy is defined by ``children`` attributes that every brick has.
+    The bricks that are not children of other bricks are called top bricks.
+    It is often useful to have access to top bricks of a brick hierarchy
+    used to build a computation graph, and here is how you can do it:
+
     >>> model.get_top_bricks() #doctest: +ELLIPSIS
     [<blocks.bricks.MLP object at ...]
-    >>> # With model you get "hierarchical" names for the parameters,
-    >>> # which encode the position of the owning brick in the
-    >>> # brick hierarchy.
+
+    You can also get "hierarchical" names for the parameters,
+    which encode the position of the owning brick in the
+    brick hierarchy.
+
     >>> model.get_parameter_dict() #doctest: +NORMALIZE_WHITESPACE
     OrderedDict([('/mlp/linear_1.b', b), ('/mlp/linear_0.b', b),
     ('/mlp/linear_0.W', W), ('/mlp/linear_1.W', W)])
@@ -81,7 +92,7 @@ class Model(ComputationGraph):
         in the bricks hierarchy. The variable names are used for the
         parameters that do not belong to any brick.
 
-        Returns:
+        Returns
         -------
         parameter_dict : dict
             A dictionary of (hierarchical name, shared variable) pairs.
@@ -135,7 +146,7 @@ class Model(ComputationGraph):
     def get_top_bricks(self):
         """Get the bricks that do not have parents.
 
-        Returns:
+        Returns
         -------
         bricks : list of :class:`~blocks.bricks.base.Brick`
 

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -78,8 +78,8 @@ class Model(ComputationGraph):
             raise ValueError("top bricks with the same name:"
                              " {}".format(', '.join(repeated_names)))
         brick_parameter_names = {
-            v: k for k, v in six.iteritems(Selector(
-                self.top_bricks).get_parameters())}
+            v: k for k, v in Selector(
+                self.top_bricks).get_parameters().items()}
         parameter_list = []
         for parameter in self.parameters:
             if parameter in brick_parameter_names:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,8 @@ from numpy.testing import assert_allclose, assert_raises
 
 from blocks.bricks import MLP, Tanh
 from blocks.model import Model
+from blocks.graph import add_role, PARAMETER
+from blocks.utils import shared_floatx
 
 
 def test_model():
@@ -14,7 +16,7 @@ def test_model():
     h1 = mlp1.apply(x)
     h2 = mlp2.apply(h1)
 
-    model = Model(h2.sum())
+    model = Model(h2)
     assert model.get_top_bricks() == [mlp1, mlp2]
     # The order of parameters returned is deterministic but
     # not sensible.
@@ -50,3 +52,12 @@ def test_model():
     def helper():
         Model(mlp4.apply(mlp3.apply(x)))
     assert_raises(ValueError, helper)
+
+
+def test_model_handles_brickless_parameteres():
+    x = tensor.matrix('x')
+    v = shared_floatx(numpy.zeros((10, 10)), name='V')
+    add_role(v, PARAMETER)
+    y = x.dot(v)
+    model = Model(y)
+    assert list(model.get_parameter_dict().items()) == [('V', v)]


### PR DESCRIPTION
Fixes  #613.

This PR tries to make the concept of Blocks model very simple. It basically follows what @bartvm proposed half-a-year ago. The generality will kind of drop if it is merged, because e.g. an extension that requests `model.parameters` will not work with pure Theano graphs, for which `model.shared_variables` should be used. 

In the future development, this lack of generality can be addressed by introducing `ExtensionConfig` class, an instance of which would be an attribute of every main loop object. Then, a good extension would request `model.extension_config.parameters`, and at this point the user can intercept the request and make `ExtensionConfig` return `shared_variables`. However, I think it is reasonable to make an incremental improvement first by merging this PR and significantly reducing WTF-level for people trying to understand the current `Model`, which basically combines `ExtensionConfig` and a `ComputationGraph` extension. This is especially important before the tutorial scheduled for October 15.

@dwf, could you please review it?