### PR TITLE
Make Convolutional's conv implementation hackable.

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -44,7 +44,6 @@ class Convolutional(Initializable):
         Defaults to ``False``.
 
     """
-
     # Make it possible to override the implementation of conv2d that gets
     # used, i.e. to use theano.sandbox.cuda.dnn.dnn_conv directly in order
     # to leverage features not yet available in Theano's standard conv2d.

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -44,6 +44,13 @@ class Convolutional(Initializable):
         Defaults to ``False``.
 
     """
+
+    # Make it possible to override the implementation of conv2d that gets
+    # used, i.e. to use theano.sandbox.cuda.dnn.dnn_conv directly in order
+    # to leverage features not yet available in Theano's standard conv2d.
+    conv2d_impl = staticmethod(conv2d)
+    get_output_shape = staticmethod(ConvOp.getOutputShape)
+
     @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])
     def __init__(self, filter_size, num_filters, num_channels, batch_size=None,
                  image_size=(None, None), step=(1, 1), border_mode='valid',
@@ -124,7 +131,7 @@ class Convolutional(Initializable):
             image_shape = (self.batch_size, self.num_channels)
             image_shape += self.image_size
 
-        output = conv2d(
+        output = self.conv2d_impl(
             input_, W,
             image_shape=image_shape,
             subsample=self.step,
@@ -143,7 +150,7 @@ class Convolutional(Initializable):
             return (self.num_channels,) + self.image_size
         if name == 'output':
             return ((self.num_filters,) +
-                    ConvOp.getOutputShape(self.image_size, self.filter_size,
+                    self.get_output_shape(self.image_size, self.filter_size,
                                           self.step, self.border_mode))
         return super(Convolutional, self).get_dim(name)
 

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -47,7 +47,16 @@ class Convolutional(Initializable):
     # Make it possible to override the implementation of conv2d that gets
     # used, i.e. to use theano.sandbox.cuda.dnn.dnn_conv directly in order
     # to leverage features not yet available in Theano's standard conv2d.
+    # The function you override with here should accept at least the
+    # input and the kernels as positionals, and the keyword arguments
+    # image_shape, subsample, border_mode, and filter_shape. If some of
+    # these are unsupported they should still be accepted and ignored,
+    # e.g. with a wrapper function that swallows **kwargs.
     conv2d_impl = staticmethod(conv2d)
+
+    # Used to override the output shape computation for a given value of
+    # conv2d_impl. Should accept 4 positional arguments: the image size,
+    # the filter size, the step (strides), and the border mode.
     get_output_shape = staticmethod(ConvOp.getOutputShape)
 
     @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])


### PR DESCRIPTION
This enables a workaround for using some experimental Theano functionality not yet available in the mainline convolution ops. It's a small change that simplifies user code greatly in this respect.