### PR TITLE
warn if setting wrong shape parameters

### DIFF
--- a/blocks/model.py
+++ b/blocks/model.py
@@ -99,6 +99,11 @@ class AbstractModel(object):
 
         for name, value in parameter_values.items():
             if name in parameters:
+                model_shape = parameters[name].container.data.shape
+                if model_shape != value.shape:
+                    raise ValueError("Shape mismatch for parameter: {}. "
+                                     "Expected {}, got {}."
+                                     .format(name, model_shape, value.shape))
                 parameters[name].set_value(value)
 
     @abstractmethod

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -44,6 +44,15 @@ def test_model():
     for name, value in parameter_values.items():
         assert_allclose(value, got_parameter_values[name])
 
+    # Test exception is raised if parameter shapes don't match
+    def helper():
+        parameter_values = {
+            '/mlp/linear_0.W': 2 * numpy.ones((11, 11),
+                                              dtype=theano.config.floatX),
+            '/mlp/linear_0.b': 3 * numpy.ones(11, dtype=theano.config.floatX)}
+        model3.set_parameter_values(parameter_values)
+    assert_raises(ValueError, helper)
+
     # Test name conflict handling
     mlp4 = MLP([Tanh()], [10, 10])
 


### PR DESCRIPTION
Setting the wrong weight shape for a model is surprisingly hard to debug as it generally results in a runtime error. This pull request warns the user in this case.