### PR TITLE
Improved the error message when an application decorator is missing.

### DIFF
--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -296,7 +296,9 @@ class Application(object):
                 brick not in last_brick.children):
             raise ValueError('Brick ' + str(self.call_stack[-1]) + ' tries '
                              'to call brick ' + str(self.brick) + ' which '
-                             'is not in the list of its children.')
+                             'is not in the list of its children. This could '
+                             'be caused because an @application decorator is '
+                             'missing.')
         self.call_stack.append(brick)
         try:
             outputs = self.application_function(brick, *args, **kwargs)


### PR DESCRIPTION
Just a bit of documentation. Added a comment on the error message that states that a missing application decorator might be the reason behind the error.