### PR TITLE
Convolutional network pooling improvements

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -167,7 +167,6 @@ class Convolutional(Initializable):
         return self.num_filters
 
 
-
 class Pooling(Initializable, Feedforward):
     """Base Brick for pooling operations.
 
@@ -278,6 +277,34 @@ class MaxPooling(Pooling):
                                          step=step, input_dim=input_dim,
                                          ignore_border=ignore_border,
                                          padding=padding, **kwargs)
+
+
+class AveragePooling(Pooling):
+    """Average pooling layer.
+
+    Parameters
+    ----------
+    include_padding : bool, optional
+        When calculating an average, include zeros that are the
+        result of zero padding added by the `padding` argument.
+        A value of `True` is only accepted if `ignore_border`
+        is also `True`. `False` by default.
+
+    Notes
+    -----
+    For documentation on the remainder of the arguments to this
+    class, see :class:`MaxPooling`.
+
+    """
+    @lazy(allocation=['pooling_size'])
+    def __init__(self, pooling_size, step=None, input_dim=None,
+                 ignore_border=False, padding=(0, 0),
+                 include_padding=False, **kwargs):
+        mode = 'average_inc_pad' if include_padding else 'average_exc_pad'
+        super(AveragePooling, self).__init__(mode, pooling_size,
+                                             step=step, input_dim=input_dim,
+                                             ignore_border=ignore_border,
+                                             padding=padding, **kwargs)
 
 
 class _AllocationMixin(object):

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -292,6 +292,13 @@ class MaxPooling(Pooling):
                                          ignore_border=ignore_border,
                                          padding=padding, **kwargs)
 
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # Fix objects created before pull request #899.
+        self.mode = getattr(self, 'mode', 'max')
+        self.padding = getattr(self, 'padding', (0, 0))
+        self.ignore_border = getattr(self, 'ignore_border', False)
+
 
 class AveragePooling(Pooling):
     """Average pooling layer.

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -175,8 +175,8 @@ class Pooling(Initializable, Feedforward):
 
     """
     @lazy(allocation=['mode', 'pooling_size'])
-    def __init__(self, mode, pooling_size, step=None, input_dim=None,
-                 ignore_border=False, padding=(0, 0), **kwargs):
+    def __init__(self, mode, pooling_size, step, input_dim, ignore_border,
+                 padding, **kwargs):
         super(Pooling, self).__init__(**kwargs)
         self.pooling_size = pooling_size
         self.mode = mode
@@ -266,12 +266,26 @@ class MaxPooling(Pooling):
         the extent of the pooling region reaches beyond the edge of the
         image. If `True`, a (5, 5) image with (2, 2) pooling regions
         and (2, 2) step will be downsampled to shape (2, 2), otherwise
-        it will be downsampled to (3, 3). `False` by default.
+        it will be downsampled to (3, 3). `True` by default.
+
+    Notes
+    -----
+    .. warning::
+        As of this writing, setting `ignore_border` to `False` with a step
+        not equal to the pooling size will force Theano to perform pooling
+        computations on CPU rather than GPU, even if you have specified
+        a GPU as your computation device. Additionally, Theano will only
+        use [cuDNN]_ (if available) for pooling computations with
+        `ignure_border` set to `True`. You can ensure that the entire
+        input is captured by at least one pool by using the `padding`
+        argument to add zero padding prior to pooling being performed.
+
+    .. [cuDNN]: `NVIDIA cuDNN <https://developer.nvidia.com/cudnn>`_.
 
     """
     @lazy(allocation=['pooling_size'])
     def __init__(self, pooling_size, step=None, input_dim=None,
-                 ignore_border=False, padding=(0, 0),
+                 ignore_border=True, padding=(0, 0),
                  **kwargs):
         super(MaxPooling, self).__init__('max', pooling_size,
                                          step=step, input_dim=input_dim,
@@ -298,7 +312,7 @@ class AveragePooling(Pooling):
     """
     @lazy(allocation=['pooling_size'])
     def __init__(self, pooling_size, step=None, input_dim=None,
-                 ignore_border=False, padding=(0, 0),
+                 ignore_border=True, padding=(0, 0),
                  include_padding=False, **kwargs):
         mode = 'average_inc_pad' if include_padding else 'average_exc_pad'
         super(AveragePooling, self).__init__(mode, pooling_size,

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -162,6 +162,11 @@ class Convolutional(Initializable):
                                           self.step, self.border_mode))
         return super(Convolutional, self).get_dim(name)
 
+    @property
+    def num_output_channels(self):
+        return self.num_filters
+
+
 
 class Pooling(Initializable, Feedforward):
     """Base Brick for pooling operations.
@@ -229,6 +234,10 @@ class Pooling(Initializable, Feedforward):
                 self.input_dim, self.pooling_size, st=self.step,
                 ignore_border=self.ignore_border, padding=self.padding))
 
+    @property
+    def num_output_channels(self):
+        return self.input_dim[0]
+
 
 class MaxPooling(Pooling):
     """Max pooling layer.
@@ -277,6 +286,14 @@ class _AllocationMixin(object):
                      'batch_size', 'num_channels', 'image_size',
                      'tied_biases', 'use_bias']:
             setattr(self.convolution, attr, getattr(self, attr))
+
+    @property
+    def num_output_channels(self):
+        # Assumes an elementwise activation function. Would need to
+        # change to support e.g. maxout, but that would also require
+        # a way of querying the activation function for this kind of
+        # information.
+        return self.num_filters
 
 
 class ConvolutionalActivation(_AllocationMixin, Sequence, Initializable):
@@ -478,7 +495,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
             if layer.image_size is not None:
                 output_shape = layer.get_dim('output')
                 image_size = output_shape[1:]
-            num_channels = layer.num_filters
+            num_channels = layer.num_output_channels
 
 
 class Flattener(Brick):

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -171,6 +171,11 @@ def test_max_pooling_old_pickle():
         loaded.apply(tensor.tensor4())
     except Exception:
         raise AssertionError("failed to apply on unpickled MaxPooling")
+    # Make sure we're not overriding these attributes wrongly.
+    new_brick = MaxPooling((4, 3), padding=(2, 1))
+    new_brick_unpickled = pickle.loads(pickle.dumps(new_brick))
+    assert new_brick_unpickled.padding == (2, 1)
+    assert new_brick_unpickled.ignore_border
 
 
 def test_average_pooling():

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -118,8 +118,8 @@ def test_max_pooling():
                        dtype=theano.config.floatX)
     assert_allclose(func(x_val),
                     numpy.ones((batch_size, num_channels,
-                                x_size / pool_size + 1,
-                                y_size / pool_size + 1)))
+                                x_size / pool_size,
+                                y_size / pool_size)))
     pool.input_dim = (x_size, y_size)
     pool.get_dim('output') == (num_channels, x_size / pool_size + 1,
                                y_size / pool_size + 1)
@@ -217,7 +217,7 @@ def test_convolutional_layer():
     x_val = numpy.ones((batch_size, num_channels, 17, 13),
                        dtype=theano.config.floatX)
     assert_allclose(func(x_val), numpy.prod(filter_size) * num_channels *
-                    numpy.ones((batch_size, num_filters, 5, 4)) + 5)
+                    numpy.ones((batch_size, num_filters, 5, 3)) + 5)
 
     assert_equal(conv.convolution.batch_size, batch_size)
     assert_equal(conv.pooling.batch_size, batch_size)
@@ -248,7 +248,7 @@ def test_convolutional_sequence():
     func = function([x], y)
 
     x_val = numpy.ones((batch_size, 4, 17, 13), dtype=theano.config.floatX)
-    y_val = (numpy.ones((batch_size, 4, 4, 3)) *
+    y_val = (numpy.ones((batch_size, 4, 4, 2)) *
              (9 * 4 + 5) * 4 * 5)
     assert_allclose(func(x_val), y_val)
 

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -182,6 +182,18 @@ def test_average_pooling_exc_padding():
     assert_allclose(x_, output)
 
 
+def test_pooling_works_in_convolutional_sequence():
+    x = tensor.tensor4('x')
+    brick = ConvolutionalSequence([AveragePooling((2, 2), step=(2, 2)),
+                                   MaxPooling((4, 4), step=(2, 2),
+                                              ignore_border=True)],
+                                  image_size=(16, 32), num_channels=3)
+    brick.allocate()
+    y = brick.apply(x)
+    out = y.eval({x: numpy.empty((2, 3, 16, 32), dtype=theano.config.floatX)})
+    assert out.shape == (2, 3, 3, 7)
+
+
 def test_convolutional_layer():
     x = tensor.tensor4('x')
     num_channels = 4


### PR DESCRIPTION
This pull request accomplishes a few things:
* Most notably, an AveragePooling Brick (mentioned in #257), accomplished by refactoring MaxPooling into a base Pooling Brick and MaxPooling and AveragePooling descendants.
  * Tests for AveragePooling's two modes w.r.t. padding.
* More complete wrapping of Theano's `max_pool_2d` function (which, bizarrely, also handles average pooling)
  * Basic tests for these.
* Improvements to ConvolutionalSequence that let you use MaxPooling (and AveragePooling) without ConvolutionalLayer, and make the interface a bit more coherent (i.e. not directly querying `num_filters` for the number of output channels, which is not always the case e.g. with a convolutional maxout layer or something)
* **Change the default `ignore_border` mode to `False`**, while exposing it in an option, with a warning in the docs that modifying it (with certain step configurations) can force computation onto the CPU.

Fixes #894, and an item in #257 that should be crossed off there.