### PR TITLE
Add API sections for two log backends

### DIFF
--- a/docs/api/log.rst
+++ b/docs/api/log.rst
@@ -3,7 +3,26 @@
 Logging
 =======
 
+Log has two different backends configurable in ``.blocksrc``,
+see :doc:`../configuration`.
+
 .. automodule:: blocks.log
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Dictionary backend
+------------------
+
+.. automodule:: blocks.log.log
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Sqlite backend
+--------------
+
+.. automodule:: blocks.log.sqlite
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
I've heard many complaints that log is not documented, here is the fix.