### PR TITLE
copy constructor for TheanoVariables doesn't take 'name' kwarg. 

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -239,7 +239,7 @@ class GradientDescent(DifferentiableCostMinimizer):
 
         self.total_step_norm = l2_norm(
             self.steps.values()).copy()
-        self.total_step_norm.name="total_step_norm"
+        self.total_step_norm.name = "total_step_norm"
 
         self.on_unused_sources = on_unused_sources
         self.theano_func_kwargs = (theano_func_kwargs if theano_func_kwargs

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -231,11 +231,16 @@ class GradientDescent(DifferentiableCostMinimizer):
         self.step_rule = step_rule if step_rule else Scale()
 
         self.total_gradient_norm = l2_norm(
-            self.gradients.values()).copy(name="total_gradient_norm")
+            self.gradients.values()).copy()
+        self.total_gradient_norm.name = "total_gradient_norm"
+
         self.steps, self.step_rule_updates = (
             self.step_rule.compute_steps(self.gradients))
+
         self.total_step_norm = l2_norm(
-            self.steps.values()).copy(name="total_step_norm")
+            self.steps.values()).copy()
+        self.total_step_norm.name="total_step_norm"
+
         self.on_unused_sources = on_unused_sources
         self.theano_func_kwargs = (theano_func_kwargs if theano_func_kwargs
                                    is not None else dict())


### PR DESCRIPTION
When stepping through the blocks tutorial, I experienced a crash. The root cause was that TensorVariables inherit their copy constructor from _tensor_py_operators. This copy function does not take 'name' as a kwarg. 

So, I split the copy and assignment of the name attribute into 2 steps. Other solutions might be giving the copy constructor a name kwarg with a default value of None and then assigning the name within the copy constructor, if it has been provided. Or, restoring the named_copy function, which appears to have existed at one point. Since I'm not a Theano expert, I'm going with the smallest, local change I could make.