### PR TITLE
ConvolutionTranspose

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -294,7 +294,7 @@ class ConvolutionalTranspose(Initializable):
             W, b = self.parameters
         else:
             W, = self.parameters
-        imshp = tensor.stack(*((input_.shape[0],) + self.get_dim('output')))
+        imshp = (None,) + self.get_dim('output')
         kshp = (self.num_channels, self.num_filters) + self.filter_size
         output = AbstractConv2d_gradInputs(
             imshp=imshp, kshp=kshp, border_mode=self.border_mode,

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -1,5 +1,5 @@
 from theano.tensor.nnet.conv import conv2d, get_conv_output_shape
-from theano.tensor.signal.downsample import max_pool_2d, DownsampleFactorMax
+from theano.tensor.signal.pool import pool_2d, Pool
 
 from blocks.bricks import Initializable, Feedforward, Sequence
 from blocks.bricks.base import application, Brick, lazy
@@ -230,16 +230,16 @@ class Pooling(Initializable, Feedforward):
             with the last two dimensions downsampled.
 
         """
-        output = max_pool_2d(input_, self.pooling_size, st=self.step,
-                             mode=self.mode, padding=self.padding,
-                             ignore_border=self.ignore_border)
+        output = pool_2d(input_, self.pooling_size, st=self.step,
+                         mode=self.mode, padding=self.padding,
+                         ignore_border=self.ignore_border)
         return output
 
     def get_dim(self, name):
         if name == 'input_':
             return self.input_dim
         if name == 'output':
-            return tuple(DownsampleFactorMax.out_shape(
+            return tuple(Pool.out_shape(
                 self.input_dim, self.pooling_size, st=self.step,
                 ignore_border=self.ignore_border, padding=self.padding))
 

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -1,6 +1,7 @@
 from theano import tensor
 from theano.tensor.nnet import conv2d
-from theano.tensor.nnet.abstract_conv import get_conv_output_shape
+from theano.tensor.nnet.abstract_conv import (AbstractConv2d_gradInputs,
+                                              get_conv_output_shape)
 from theano.tensor.signal.pool import pool_2d, Pool
 
 from blocks.bricks import Initializable, Feedforward, Sequence

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -1,4 +1,5 @@
-from theano.tensor.nnet.conv import conv2d, get_conv_output_shape
+from theano.tensor.nnet import conv2d
+from theano.tensor.nnet.abstract_conv import get_conv_output_shape
 from theano.tensor.signal.pool import pool_2d, Pool
 
 from blocks.bricks import Initializable, Feedforward, Sequence

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -187,8 +187,20 @@ class ConvolutionalTranspose(Convolutional):
     ----------
     image_size : tuple, optional
         Required for tied biases. Defaults to ``None``.
+    num_filters : int
+        Number of filters at the *output* of the transposed convolution,
+        i.e. the number of channels in the corresponding convolution.
+    num_channels : int
+        Number of channels at the *input* of the transposed convolution,
+        i.e. the number of output filters in the corresponding
+        convolution.
     original_image_size : tuple
-        The height and width of the output (image or feature map).
+        The height and width of the image that forms the output of
+        the transpose operation, which is the input of the original
+        (non-transposed) convolution.
+    step : tuple, optional
+        The step (or stride) of the corresponding *convolution*.
+        Defaults to (1, 1).
 
     See Also
     --------

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -580,7 +580,7 @@ class ConvolutionalTransposeActivation(_AllocationMixin, Sequence,
         return self.convolution.get_dim(name)
 
     def _push_allocation_config(self):
-        super(ConvolutionalActivation, self)._push_allocation_config()
+        super(ConvolutionalTransposeActivation, self)._push_allocation_config()
         self.convolution.step = self.step
         self.convolution.original_image_size = self.original_image_size
 

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -1,3 +1,4 @@
+from theano import tensor
 from theano.tensor.nnet import conv2d
 from theano.tensor.nnet.abstract_conv import get_conv_output_shape
 from theano.tensor.signal.pool import pool_2d, Pool
@@ -171,6 +172,144 @@ class Convolutional(Initializable):
                                               self.border_mode, self.step)
             assert len(out_shape) == 4
             return out_shape[1:]
+        return super(Convolutional, self).get_dim(name)
+
+    @property
+    def num_output_channels(self):
+        return self.num_filters
+
+
+class ConvolutionalTranspose(Initializable):
+    """Performs the transpose of a 2D convolution.
+
+    Parameters
+    ----------
+    filter_size : tuple
+        The height and width of the filter (also called *kernels*).
+    num_filters : int
+        Number of filters per channel.
+    num_channels : int
+        Number of input channels in the image. For the first layer this is
+        normally 1 for grayscale images and 3 for color (RGB) images. For
+        subsequent layers this is equal to the number of filters output by
+        the previous convolutional layer. The filters are pooled over the
+        channels.
+    original_image_size : tuple
+        The height and width of the output (image or feature map).
+    batch_size : int, optional
+        Number of examples per batch. If given, this will be passed to
+        Theano convolution operator, possibly resulting in faster
+        execution.
+    image_size : tuple, optional
+        The height and width of the input (image or feature map). If given,
+        this will be passed to the Theano convolution operator, resulting
+        in possibly faster execution times.
+    step : tuple, optional
+        The step (or stride) with which to slide the filters over the
+        image. Defaults to (1, 1).
+    border_mode : {'valid', 'full'}, optional
+        The border mode to use, see :func:`scipy.signal.convolve2d` for
+        details. Defaults to 'valid'.
+    tied_biases : bool
+        If ``True``, it indicates that the biases of every filter in this
+        layer should be shared amongst all applications of that filter.
+        Setting this to ``False`` will untie the biases, yielding a
+        separate bias for every location at which the filter is applied.
+        Defaults to ``False``.
+
+    """
+    @lazy(allocation=['filter_size', 'num_filters', 'num_channels',
+                      'original_image_size'])
+    def __init__(self, filter_size, num_filters, num_channels,
+                 original_image_size, batch_size=None, image_size=(None, None),
+                 step=(1, 1), border_mode='valid', tied_biases=False,
+                 **kwargs):
+        super(ConvolutionalTranspose, self).__init__(**kwargs)
+
+        self.filter_size = filter_size
+        self.num_filters = num_filters
+        self.batch_size = batch_size
+        self.num_channels = num_channels
+        self.image_size = image_size
+        self.original_image_size = original_image_size
+        self.step = step
+        self.border_mode = border_mode
+        self.tied_biases = tied_biases
+
+    def _allocate(self):
+        # The GpuDnnConvGradI op takes a kernel that was used for the
+        # **convolution**. We therefore have to invert num_channels
+        # and num_filters for W.
+        W = shared_floatx_nans((self.num_channels, self.num_filters) +
+                               self.filter_size, name='W')
+        add_role(W, FILTER)
+        self.parameters.append(W)
+        self.add_auxiliary_variable(W.norm(2), name='W_norm')
+        if self.use_bias:
+            if self.tied_biases:
+                b = shared_floatx_nans((self.num_filters,), name='b')
+            else:
+                # this error is raised here instead of during initializiation
+                # because ConvolutionalSequence may specify the image size
+                if self.image_size == (None, None) and not self.tied_biases:
+                    raise ValueError('Cannot infer bias size without '
+                                     'image_size specified. If you use '
+                                     'variable image_size, you should use '
+                                     'tied_biases=True.')
+
+                b = shared_floatx_nans(self.get_dim('output'), name='b')
+            add_role(b, BIAS)
+
+            self.parameters.append(b)
+            self.add_auxiliary_variable(b.norm(2), name='b_norm')
+
+    def _initialize(self):
+        if self.use_bias:
+            W, b = self.parameters
+            self.biases_init.initialize(b, self.rng)
+        else:
+            W, = self.parameters
+        self.weights_init.initialize(W, self.rng)
+
+    @application(inputs=['input_'], outputs=['output'])
+    def apply(self, input_):
+        """Perform the transposed convolution.
+
+        Parameters
+        ----------
+        input_ : :class:`~tensor.TensorVariable`
+            A 4D tensor with the axes representing batch size, number of
+            channels, image height, and image width.
+
+        Returns
+        -------
+        output : :class:`~tensor.TensorVariable`
+            A 4D tensor of filtered images (feature maps) with dimensions
+            representing batch size, number of filters, feature map height,
+            and feature map width.
+
+        """
+        if self.use_bias:
+            W, b = self.parameters
+        else:
+            W, = self.parameters
+        out_shape = tensor.stack(
+            *((input_.shape[0],) + self.get_dim('output')))
+        output = AbstractConv2d_gradInputs(
+            imshp=out_shape, kshp=W.shape, border_mode=self.border_mode,
+            subsample=self.step)(W, input_, out_shape[-2:])
+        if self.use_bias:
+            if self.tied_biases:
+                output += b.dimshuffle('x', 0, 'x', 'x')
+            else:
+                output += b.dimshuffle('x', 0, 1, 2)
+        return output
+
+    def get_dim(self, name):
+        if name == 'input_':
+            return (self.num_channels,) + self.image_size
+        if name == 'output':
+            return (self.num_filters,) + self.original_image_size
         return super(Convolutional, self).get_dim(name)
 
     @property
@@ -395,6 +534,54 @@ class ConvolutionalActivation(_AllocationMixin, Sequence, Initializable):
     def _push_allocation_config(self):
         super(ConvolutionalActivation, self)._push_allocation_config()
         self.convolution.step = self.step
+
+
+class ConvolutionalTransposeActivation(_AllocationMixin, Sequence,
+                                       Initializable):
+    """A transposed convolution followed by an activation function.
+
+    Parameters
+    ----------
+    activation : :class:`.BoundApplication`
+        The application method to apply after convolution (i.e.
+        the nonlinear activation function)
+
+    See Also
+    --------
+    :class:`ConvolutionalTranspose` : For the documentation of other
+    parameters.
+
+    """
+    @lazy(allocation=['filter_size', 'num_filters', 'num_channels',
+                      'original_image_size'])
+    def __init__(self, activation, filter_size, num_filters, num_channels,
+                 original_image_size, batch_size=None, image_size=None,
+                 step=(1, 1), border_mode='valid', tied_biases=False,
+                 **kwargs):
+        self.convolution = ConvolutionalTranspose()
+
+        self.filter_size = filter_size
+        self.num_filters = num_filters
+        self.num_channels = num_channels
+        self.batch_size = batch_size
+        self.image_size = image_size
+        self.original_image_size = original_image_size
+        self.step = step
+        self.border_mode = border_mode
+        self.tied_biases = tied_biases
+
+        super(ConvolutionalTransposeActivation, self).__init__(
+            application_methods=[self.convolution.apply, activation],
+            **kwargs)
+
+    def get_dim(self, name):
+        # TODO The name of the activation output doesn't need to be `output`
+        return self.convolution.get_dim(name)
+
+    def _push_allocation_config(self):
+        super(ConvolutionalActivation, self)._push_allocation_config()
+        self.convolution.step = self.step
+        self.convolution.original_image_size = self.original_image_size
 
 
 class ConvolutionalSequence(Sequence, Initializable, Feedforward):

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -513,7 +513,7 @@ class ConvolutionalActivation(_AllocationMixin, Sequence, Initializable):
     def __init__(self, activation, filter_size, num_filters, num_channels,
                  batch_size=None, image_size=None, step=(1, 1),
                  border_mode='valid', tied_biases=False, **kwargs):
-        self.convolution = Convolutional()
+        self._build_convolution()
 
         self.filter_size = filter_size
         self.num_filters = num_filters
@@ -527,6 +527,9 @@ class ConvolutionalActivation(_AllocationMixin, Sequence, Initializable):
         super(ConvolutionalActivation, self).__init__(
             application_methods=[self.convolution.apply, activation],
             **kwargs)
+
+    def _build_convolution(self):
+        self.convolution = Convolutional()
 
     def get_dim(self, name):
         # TODO The name of the activation output doesn't need to be `output`
@@ -559,21 +562,15 @@ class ConvolutionalTransposeActivation(_AllocationMixin, Sequence,
                  original_image_size, batch_size=None, image_size=None,
                  step=(1, 1), border_mode='valid', tied_biases=False,
                  **kwargs):
-        self.convolution = ConvolutionalTranspose()
-
-        self.filter_size = filter_size
-        self.num_filters = num_filters
-        self.num_channels = num_channels
-        self.batch_size = batch_size
-        self.image_size = image_size
-        self.original_image_size = original_image_size
-        self.step = step
-        self.border_mode = border_mode
-        self.tied_biases = tied_biases
-
         super(ConvolutionalTransposeActivation, self).__init__(
-            application_methods=[self.convolution.apply, activation],
+            activation, filter_size, num_filters, num_channels,
+            batch_size, image_size, step, border_mode, tied_biases,
             **kwargs)
+
+        self.original_image_size = original_image_size
+
+    def _build_convolution(self):
+        self.convolution = ConvolutionalTranspose()
 
     def get_dim(self, name):
         # TODO The name of the activation output doesn't need to be `output`

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -52,7 +52,7 @@ class Convolutional(Initializable):
     # to leverage features not yet available in Theano's standard conv2d.
     # The function you override with here should accept at least the
     # input and the kernels as positionals, and the keyword arguments
-    # image_shape, subsample, border_mode, and filter_shape. If some of
+    # input_shape, subsample, border_mode, and filter_shape. If some of
     # these are unsupported they should still be accepted and ignored,
     # e.g. with a wrapper function that swallows **kwargs.
     conv2d_impl = staticmethod(conv2d)
@@ -143,14 +143,14 @@ class Convolutional(Initializable):
             W, = self.parameters
 
         if self.image_size == (None, None):
-            image_shape = None
+            input_shape = None
         else:
-            image_shape = (self.batch_size, self.num_channels)
-            image_shape += self.image_size
+            input_shape = (self.batch_size, self.num_channels)
+            input_shape += self.image_size
 
         output = self.conv2d_impl(
             input_, W,
-            image_shape=image_shape,
+            input_shape=input_shape,
             subsample=self.step,
             border_mode=self.border_mode,
             filter_shape=((self.num_filters, self.num_channels) +
@@ -166,10 +166,10 @@ class Convolutional(Initializable):
         if name == 'input_':
             return (self.num_channels,) + self.image_size
         if name == 'output':
-            image_shape = (None, self.num_channels) + self.image_size
+            input_shape = (None, self.num_channels) + self.image_size
             kernel_shape = ((self.num_filters, self.num_channels) +
                             self.filter_size)
-            out_shape = self.get_output_shape(image_shape, kernel_shape,
+            out_shape = self.get_output_shape(input_shape, kernel_shape,
                                               self.border_mode, self.step)
             assert len(out_shape) == 4
             return out_shape[1:]

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -294,11 +294,11 @@ class ConvolutionalTranspose(Initializable):
             W, b = self.parameters
         else:
             W, = self.parameters
-        out_shape = tensor.stack(
-            *((input_.shape[0],) + self.get_dim('output')))
+        imshp = tensor.stack(*((input_.shape[0],) + self.get_dim('output')))
+        kshp = (self.num_channels, self.num_filters) + self.filter_size
         output = AbstractConv2d_gradInputs(
-            imshp=out_shape, kshp=W.shape, border_mode=self.border_mode,
-            subsample=self.step)(W, input_, out_shape[-2:])
+            imshp=imshp, kshp=kshp, border_mode=self.border_mode,
+            subsample=self.step)(W, input_, imshp[-2:])
         if self.use_bias:
             if self.tied_biases:
                 output += b.dimshuffle('x', 0, 'x', 'x')

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -237,9 +237,9 @@ class ConvolutionalTranspose(Initializable):
         self.tied_biases = tied_biases
 
     def _allocate(self):
-        # The GpuDnnConvGradI op takes a kernel that was used for the
-        # **convolution**. We therefore have to invert num_channels
-        # and num_filters for W.
+        # The AbstractConv2d_gradInputs op takes a kernel that was used for the
+        # **convolution**. We therefore have to invert num_channels and
+        # num_filters for W.
         W = shared_floatx_nans((self.num_channels, self.num_filters) +
                                self.filter_size, name='W')
         add_role(W, FILTER)
@@ -310,7 +310,7 @@ class ConvolutionalTranspose(Initializable):
             return (self.num_channels,) + self.image_size
         if name == 'output':
             return (self.num_filters,) + self.original_image_size
-        return super(Convolutional, self).get_dim(name)
+        return super(ConvolutionalTranspose, self).get_dim(name)
 
     @property
     def num_output_channels(self):

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -26,7 +26,7 @@ def test_convolutional():
                          biases_init=Constant(5.))
     conv.initialize()
     y = conv.apply(x)
-    func = function([x], y)
+    func = function([x], y, mode='FAST_RUN')
 
     x_val = numpy.ones((batch_size, num_channels, 17, 13),
                        dtype=theano.config.floatX)
@@ -53,7 +53,7 @@ def test_convolutional_transpose():
         weights_init=Constant(1.), biases_init=Constant(5.))
     conv.initialize()
     y = conv.apply(x)
-    func = function([x], y)
+    func = function([x], y, mode='FAST_RUN')
 
     x_val = numpy.ones((batch_size, num_channels) + image_size,
                        dtype=theano.config.floatX)
@@ -115,7 +115,7 @@ def test_tied_biases():
                          tied_biases=True)
     conv.initialize()
     y = conv.apply(x)
-    func = function([x], y)
+    func = function([x], y, mode='FAST_RUN')
 
     # Tied biases allows to pass images of different sizes
     x_val_1 = numpy.ones((batch_size, num_channels, 10,
@@ -140,7 +140,7 @@ def test_max_pooling():
     pool_size = 3
     pool = MaxPooling((pool_size, pool_size))
     y = pool.apply(x)
-    func = function([x], y)
+    func = function([x], y, mode='FAST_RUN')
 
     x_val = numpy.ones((batch_size, num_channels, x_size, y_size),
                        dtype=theano.config.floatX)
@@ -272,7 +272,7 @@ def test_convolutional_sequence():
     conv2.convolution.use_bias = False
     y = seq.apply(x)
     seq.initialize()
-    func = function([x], y)
+    func = function([x], y, mode='FAST_RUN')
 
     x_val = numpy.ones((batch_size, 4, 17, 13), dtype=theano.config.floatX)
     y_val = (numpy.ones((batch_size, 4, 4, 2)) *

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -8,7 +8,8 @@ from theano import tensor
 from theano import function
 
 from blocks.bricks import Rectifier
-from blocks.bricks.conv import (Convolutional, MaxPooling, AveragePooling,
+from blocks.bricks.conv import (Convolutional, ConvolutionalTranspose,
+                                MaxPooling, AveragePooling,
                                 ConvolutionalActivation, ConvolutionalSequence)
 from blocks.initialization import Constant
 from blocks.graph import ComputationGraph
@@ -35,6 +36,33 @@ def test_convolutional():
     conv.image_size = (17, 13)
     conv.batch_size = 2  # This should have effect on get_dim
     assert conv.get_dim('output') == (num_filters, 15, 11)
+
+
+def test_convolutional_transpose():
+    x = tensor.tensor4('x')
+    num_channels = 4
+    num_filters = 3
+    image_size = (8, 6)
+    original_image_size = (17, 13)
+    batch_size = 5
+    filter_size = (3, 3)
+    step = (2, 2)
+    conv = ConvolutionalTranspose(
+        filter_size, num_filters, num_channels, step=step,
+        original_image_size=original_image_size, image_size=image_size,
+        weights_init=Constant(1.), biases_init=Constant(5.))
+    conv.initialize()
+    y = conv.apply(x)
+    func = function([x], y)
+
+    x_val = numpy.ones((batch_size, num_channels) + image_size,
+                       dtype=theano.config.floatX)
+    expected_value = num_channels * numpy.ones(
+        (batch_size, num_filters) + original_image_size)
+    expected_value[:, :, 2:-2:2, :] += num_channels
+    expected_value[:, :, :, 2:-2:2] += num_channels
+    expected_value[:, :, 2:-2:2, 2:-2:2] += num_channels
+    assert_allclose(func(x_val), expected_value + 5)
 
 
 def test_border_mode_not_pushed():

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -14,6 +14,12 @@ from blocks.bricks.conv import (Convolutional, ConvolutionalTranspose,
 from blocks.initialization import Constant
 from blocks.graph import ComputationGraph
 
+# NOTE : Our CI tests are run in FAST_COMPILE mode to save time, but that
+# forces the Python implementation to be used. Because CuDNN is not installed
+# on Travis, CorrMM is used, which has no Python implemenation. This means
+# we need to force the use of FAST_RUN mode in `theano.function` calls,
+# otherwise graph compilation will fail.
+
 
 def test_convolutional():
     x = tensor.tensor4('x')

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -7,10 +7,12 @@ from numpy.testing import assert_allclose
 from theano import tensor
 from theano import function
 
-from blocks.bricks import Rectifier
+from blocks.bricks import Rectifier, Tanh
 from blocks.bricks.conv import (Convolutional, ConvolutionalTranspose,
                                 MaxPooling, AveragePooling,
-                                ConvolutionalActivation, ConvolutionalSequence)
+                                ConvolutionalActivation,
+                                ConvolutionalTransposeActivation,
+                                ConvolutionalSequence)
 from blocks.initialization import Constant
 from blocks.graph import ComputationGraph
 
@@ -48,9 +50,9 @@ def test_convolutional_transpose():
     filter_size = (3, 3)
     step = (2, 2)
     conv = ConvolutionalTranspose(
-        filter_size, num_filters, num_channels, step=step,
-        original_image_size=original_image_size, image_size=image_size,
-        weights_init=Constant(1.), biases_init=Constant(5.))
+        original_image_size, filter_size, num_filters, num_channels, step=step,
+        image_size=image_size, weights_init=Constant(1.),
+        biases_init=Constant(5.))
     conv.initialize()
     y = conv.apply(x)
     func = function([x], y)
@@ -286,6 +288,33 @@ def test_convolutional_activation_use_bias():
     act.allocate()
     assert not act.convolution.use_bias
     assert len(ComputationGraph([act.apply(tensor.tensor4())]).parameters) == 1
+
+
+def test_convolutional_transpose_activation():
+    x = tensor.tensor4('x')
+    num_channels = 4
+    num_filters = 3
+    image_size = (8, 6)
+    original_image_size = (17, 13)
+    batch_size = 5
+    filter_size = (3, 3)
+    step = (2, 2)
+    conv = ConvolutionalTransposeActivation(
+        Tanh().apply, original_image_size, filter_size, num_filters,
+        num_channels, step=step, image_size=image_size,
+        weights_init=Constant(1.), biases_init=Constant(5.))
+    conv.initialize()
+    y = conv.apply(x)
+    func = function([x], y)
+
+    x_val = numpy.ones((batch_size, num_channels) + image_size,
+                       dtype=theano.config.floatX)
+    expected_value = num_channels * numpy.ones(
+        (batch_size, num_filters) + original_image_size)
+    expected_value[:, :, 2:-2:2, :] += num_channels
+    expected_value[:, :, :, 2:-2:2] += num_channels
+    expected_value[:, :, 2:-2:2, 2:-2:2] += num_channels
+    assert_allclose(func(x_val), numpy.tanh(expected_value + 5))
 
 
 def test_convolutional_sequence_use_bias():

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -14,12 +14,6 @@ from blocks.bricks.conv import (Convolutional, ConvolutionalTranspose,
 from blocks.initialization import Constant
 from blocks.graph import ComputationGraph
 
-# NOTE : Our CI tests are run in FAST_COMPILE mode to save time, but that
-# forces the Python implementation to be used. Because CuDNN is not installed
-# on Travis, CorrMM is used, which has no Python implemenation. This means
-# we need to force the use of FAST_RUN mode in `theano.function` calls,
-# otherwise graph compilation will fail.
-
 
 def test_convolutional():
     x = tensor.tensor4('x')
@@ -32,7 +26,7 @@ def test_convolutional():
                          biases_init=Constant(5.))
     conv.initialize()
     y = conv.apply(x)
-    func = function([x], y, mode='FAST_RUN')
+    func = function([x], y)
 
     x_val = numpy.ones((batch_size, num_channels, 17, 13),
                        dtype=theano.config.floatX)
@@ -59,7 +53,7 @@ def test_convolutional_transpose():
         weights_init=Constant(1.), biases_init=Constant(5.))
     conv.initialize()
     y = conv.apply(x)
-    func = function([x], y, mode='FAST_RUN')
+    func = function([x], y)
 
     x_val = numpy.ones((batch_size, num_channels) + image_size,
                        dtype=theano.config.floatX)
@@ -121,7 +115,7 @@ def test_tied_biases():
                          tied_biases=True)
     conv.initialize()
     y = conv.apply(x)
-    func = function([x], y, mode='FAST_RUN')
+    func = function([x], y)
 
     # Tied biases allows to pass images of different sizes
     x_val_1 = numpy.ones((batch_size, num_channels, 10,
@@ -146,7 +140,7 @@ def test_max_pooling():
     pool_size = 3
     pool = MaxPooling((pool_size, pool_size))
     y = pool.apply(x)
-    func = function([x], y, mode='FAST_RUN')
+    func = function([x], y)
 
     x_val = numpy.ones((batch_size, num_channels, x_size, y_size),
                        dtype=theano.config.floatX)
@@ -278,7 +272,7 @@ def test_convolutional_sequence():
     conv2.convolution.use_bias = False
     y = seq.apply(x)
     seq.initialize()
-    func = function([x], y, mode='FAST_RUN')
+    func = function([x], y)
 
     x_val = numpy.ones((batch_size, 4, 17, 13), dtype=theano.config.floatX)
     y_val = (numpy.ones((batch_size, 4, 4, 2)) *


### PR DESCRIPTION
This PR does the following:
* Implement `ConvolutionTranspose`, also colloquially called "deconvolution", like in [Zeiler et al., 2010](http://www.matthewzeiler.com/pubs/cvpr2010/cvpr2010.pdf). Currently implemented in Tensorflow under the name `conv2d_transpose`, which they describe as "the transpose (gradient) of `conv2d`".
* Implement `ConvolutionTransposeActivation`, in analogy to `ConvolutionActivation`.
* Switch to Theano's freshly-[renamed](https://github.com/Theano/Theano/pull/3679) `pool_2d` and `Pool`.
* Switch to Theano's recent `abstract_conv` interface. The convolution ops created via this interface are placeholders that get replaced at graph compilation time with the best option available.

I'm very open to feedback regarding design choices, names, etc. In particular, I'm not sure `Convolutional.conv2d_impl` and `Convolutional.get_output_shape` are needed anymore, but I'm afraid of breaking external code by removing these attributes.