### PR TITLE
Skip test_save_the_best with sqlite backend, restore sanity.

### DIFF
--- a/blocks/utils/testing.py
+++ b/blocks/utils/testing.py
@@ -76,6 +76,27 @@ def skip_if_not_available(modules=None, datasets=None, configurations=None):
             raise SkipTest
 
 
+def skip_if_configuration_set(configuration, value, message=None):
+    """Raise SkipTest if a configuration option has a certain value.
+
+    Parameters
+    ----------
+    configuration : str
+        Configuration option to check.
+    value : str
+        Value of `blocks.config.<attribute>` which should cause
+        a `SkipTest` to be raised.
+    message : str, optional
+        Reason for skipping the test.
+
+    """
+    if getattr(config, configuration) == value:
+        if message is not None:
+            raise SkipTest(message)
+        else:
+            raise SkipTest
+
+
 class MockAlgorithm(TrainingAlgorithm):
     """An algorithm that only saves data.
 

--- a/tests/extensions/test_training.py
+++ b/tests/extensions/test_training.py
@@ -18,7 +18,7 @@ from blocks.extensions.training import SharedVariableModifier, TrackTheBest
 from blocks.extensions.predicates import OnLogRecord
 from blocks.main_loop import MainLoop
 from blocks.utils import shared_floatx
-from blocks.utils.testing import MockMainLoop
+from blocks.utils.testing import MockMainLoop, skip_if_configuration_set
 
 
 def test_shared_variable_modifier():
@@ -129,6 +129,8 @@ class WriteCostExtension(TrainingExtension):
 
 
 def test_save_the_best():
+    skip_if_configuration_set('log_backend', 'sqlite',
+                              "Known to be flaky with SQLite log backend.")
     with NamedTemporaryFile(dir=config.temp_dir) as dst,\
             NamedTemporaryFile(dir=config.temp_dir) as dst_best:
         track_cost = TrackTheBest("cost", after_epoch=False, after_batch=True)


### PR DESCRIPTION
This test is flaky due to the SQLite backend not always correctly overwriting a value already set on the current row, at least on Travis (#954).

This renders the CI status flag pretty useless, so for the time being, we'll skip this test when the sqlite backend is enabled.

Fixes #942.