### PR TITLE
Add suffix option to MonitoringExtension

### DIFF
--- a/tests/extensions/test_monitoring.py
+++ b/tests/extensions/test_monitoring.py
@@ -5,7 +5,9 @@ from numpy.testing import assert_allclose
 from theano import tensor
 
 from blocks.extensions import TrainingExtension, FinishAfter
-from blocks.extensions.monitoring import TrainingDataMonitoring
+from blocks.extensions.monitoring import (
+    MonitoringExtension,
+    TrainingDataMonitoring)
 from blocks.monitoring import aggregation
 from blocks.algorithms import GradientDescent, Scale
 from blocks.utils import shared_floatx
@@ -24,6 +26,31 @@ class MeanFeaturesTimesTarget(aggregation.MonitoredQuantity):
 
     def get_aggregated_value(self):
         return self._aggregated / self._num_batches
+
+
+def test_monitoring_extension__record_name():
+    test_name = "test-test"
+
+    monitor = MonitoringExtension()
+    assert monitor._record_name(test_name) == test_name
+
+    monitor = MonitoringExtension(prefix="abc")
+    assert (monitor._record_name(test_name) ==
+            "abc" + monitor.SEPARATOR + test_name)
+
+    monitor = MonitoringExtension(suffix="abc")
+    assert (monitor._record_name(test_name) ==
+            test_name + monitor.SEPARATOR + "abc")
+
+    monitor = MonitoringExtension(prefix="abc", suffix="def")
+    assert (monitor._record_name(test_name) ==
+            "abc" + monitor.SEPARATOR + test_name + monitor.SEPARATOR + "def")
+
+    try:
+        monitor = MonitoringExtension(prefix="abc", suffix="def")
+        monitor._record_name(None)
+    except ValueError as e:
+        assert str(e) == "record name must be a string"
 
 
 def test_training_data_monitoring():


### PR DESCRIPTION
Only prefix is supported so far and I see no reasons why favoring
prefixes over suffixes and vice versa. Also, `Printing` extensions makes
it convenient to add suffixes rather than prefixes so that *quietly*
logged variables with names beginning with `_` keep naturally their *private*
property.

Right now we need to do something like this

```python
to_be_printed_monitor = DataStreamMonitoring(
    variables=[to_be_printed_variable], data_stream=data_stream,
    prefix="prefix")

_prefix_not_to_be_printed_variable = _not_to_be_printed_variable
_prefix_not_to_be_printed_variable.name = \
    "_prefix" + _not_to_be_printed_variable.name
no_to_be_printed_monitor = DataStreamMonitoring(
    variables=[_prefix_not_to_be_printed_variable], data_stream=data_stream)
```

But with suffixes we can create a single DataStreamMonitoring

```python
monitor = DataStreamMonitoring(
    variables=[to_be_printed_variable, _no_to_be_printed_variables],
    data_stream=data_stream, suffix="suffix")
```