### PR TITLE
Refactor common stuff from Linear and Convolutional

### DIFF
--- a/blocks/bricks/__init__.py
+++ b/blocks/bricks/__init__.py
@@ -2,7 +2,8 @@
 from .base import application, Brick, lazy
 from .bn import (BatchNormalization, SpatialBatchNormalization,
                  BatchNormalizedMLP)
-from .interfaces import Activation, Feedforward, Initializable, Random
+from .interfaces import (Activation, Feedforward, Initializable, LinearLike,
+                         Random)
 from .simple import (Linear, Bias, Maxout, LinearMaxout, Identity, Tanh,
                      Logistic, Softplus, Rectifier, Softmax,
                      NDimensionalSoftmax)
@@ -11,8 +12,8 @@ from .wrappers import WithExtraDims
 
 __all__ = ('application', 'Brick', 'lazy', 'BatchNormalization',
            'SpatialBatchNormalization', 'BatchNormalizedMLP',
-           'Activation', 'Feedforward', 'Initializable', 'Random',
-           'Linear', 'Bias', 'Maxout', 'LinearMaxout', 'Identity',
+           'Activation', 'Feedforward', 'Initializable', 'LinearLike',
+           'Random', 'Linear', 'Bias', 'Maxout', 'LinearMaxout', 'Identity',
            'Tanh', 'Logistic', 'Softplus', 'Rectifier', 'Softmax',
            'NDimensionalSoftmax', 'Sequence', 'FeedforwardSequence',
            'MLP', 'WithExtraDims')

--- a/blocks/bricks/interfaces.py
+++ b/blocks/bricks/interfaces.py
@@ -167,6 +167,39 @@ class Initializable(RNGMixin, Brick):
                     child.biases_init = self.biases_init
 
 
+class LinearLike(Initializable):
+    """Initializable subclass with logic for :class:`Linear`-like classes.
+
+    Notes
+    -----
+    Provides `W` and `b` properties that can be overridden in subclasses
+    to implement pre-application transformations on the weights and
+    biases.  Application methods should refer to ``self.W`` and ``self.b``
+    rather than accessing the parameters list directly.
+
+    This assumes a layout of the parameters list with the weights coming
+    first and biases (if ``use_bias`` is True) coming second.
+
+    """
+    @property
+    def W(self):
+        return self.parameters[0]
+
+    @property
+    def b(self):
+        if self.use_bias:
+            return self.parameters[1]
+        else:
+            raise AttributeError('use_bias is False')
+
+    def _initialize(self):
+        # Use self.parameters[] references in case W and b are overridden
+        # to return non-shared-variables.
+        if self.use_bias:
+            self.biases_init.initialize(self.parameters[1], self.rng)
+        self.weights_init.initialize(self.parameters[0], self.rng)
+
+
 class Random(Brick):
     """A mixin class for Bricks which need Theano RNGs.
 

--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -321,7 +321,7 @@ def add_to_dump(object_, file_, name, parameters=None, use_cpickle=False,
 
     """
     if name in ['_pkl', '_parameters']:
-        raise ValueError("_pkl and _parameters are reserved names and can't" \
+        raise ValueError("_pkl and _parameters are reserved names and can't"
                          " be used as name for your object.")
 
     external_parameters = {}
@@ -337,7 +337,7 @@ def add_to_dump(object_, file_, name, parameters=None, use_cpickle=False,
         file_.seek(0)  # To be able to read what is in the tar file already.
         with closing(tarfile.TarFile(fileobj=file_, mode='r')) as tar_file:
             if '_parameters' not in tar_file.getnames():
-                raise ValueError("There is no parameters in the archive, so" \
+                raise ValueError("There is no parameters in the archive, so"
                                  " you can't use the argument parameters.")
             else:
                 parameters = numpy.load(
@@ -346,7 +346,7 @@ def add_to_dump(object_, file_, name, parameters=None, use_cpickle=False,
                 s2 = [_unmangle_parameter_name(x)[1] for x in
                       external_parameters.values()]
                 if not s1.issuperset(s2):
-                    raise ValueError('The set of parameters is different' \
+                    raise ValueError('The set of parameters is different'
                                      ' from the one in the archive.')
 
     if use_cpickle:

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -362,6 +362,16 @@ def test_mlp():
     assert mlp.rng == mlp.linear_transformations[0].rng
 
 
+def test_mlp_prototype_argument():
+    class MyLinear(Linear):
+        pass
+    mlp = MLP(activations=[Tanh(), Tanh(), None],
+              dims=[4, 5, 6, 7], prototype=MyLinear())
+    assert all(isinstance(lt, MyLinear) for lt in mlp.linear_transformations)
+    assert all(lt.name == 'mylinear_{}'.format(i)
+               for i, lt in enumerate(mlp.linear_transformations))
+
+
 def test_mlp_apply():
     x = tensor.matrix()
     x_val = numpy.random.rand(2, 16).astype(theano.config.floatX)

--- a/tests/bricks/test_interfaces.py
+++ b/tests/bricks/test_interfaces.py
@@ -1,0 +1,20 @@
+import numpy
+import theano
+from theano import tensor
+from blocks.bricks import Linear
+from blocks.initialization import Constant, IsotropicGaussian
+
+
+def test_linearlike_subclass_initialize_works_overridden_w():
+    class NotQuiteLinear(Linear):
+        @property
+        def W(self):
+            W = super(NotQuiteLinear, self).W
+            return W / tensor.sqrt((W ** 2).sum(axis=0))
+
+    brick = NotQuiteLinear(5, 10, weights_init=IsotropicGaussian(0.02),
+                           biases_init=Constant(1))
+    brick.initialize()
+    assert not numpy.isnan(brick.parameters[0].get_value()).any()
+    numpy.testing.assert_allclose((brick.W ** 2).sum(axis=0).eval(), 1,
+                                  rtol=1e-6)


### PR DESCRIPTION
I was hacking out an implementation of [weight normalization](http://arxiv.org/abs/1602.07868) and realized that it would be significantly less code if the `W` and `b` properties that I introduced in `Linear` were a) used in the way I intended and b) existed in `Convolutional` too, so this accomplishes both (and reduces duplication to boot).