### PR TITLE
information about dimensionality for apply in rnn tutorial

### DIFF
--- a/docs/rnn.rst
+++ b/docs/rnn.rst
@@ -168,8 +168,13 @@ Iterate (or not)
 ----------------
 
 The ``apply`` method of a recurrent brick accepts an ``iterate`` argument,
-which defaults to ``True``. Setting it to ``False`` causes the ``apply`` method
-to compute only one step in the sequence.
+which defaults to ``True``. It is the reason for passing above a tensor of one
+more dimension than described in :meth:`.recurrent.SimpleRecurrent.apply` - the
+extra first dimension corresponds to the length of the sequence we are iterating
+over.
+
+Setting ``iterate`` to ``False`` causes the ``apply`` method to compute only
+one step in the sequence.
 
 This is very useful when you're trying to combine multiple recurrent layers in
 a network.


### PR DESCRIPTION
Currently the dimensionality of the tensor passed to `apply` is not well documented anywhere.

fixes #1040 