### PR TITLE
Fix some None-handling in ConvolutionalSequence for when image size is unspecified

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -440,8 +440,9 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
 
     """
     @lazy(allocation=['num_channels'])
-    def __init__(self, layers, num_channels, batch_size=None, image_size=None,
-                 border_mode=None, tied_biases=None, **kwargs):
+    def __init__(self, layers, num_channels, batch_size=None,
+                 image_size=(None, None), border_mode=None, tied_biases=None,
+                 **kwargs):
         self.layers = layers
         self.image_size = image_size
         self.num_channels = num_channels
@@ -491,7 +492,7 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
 
             # Retrieve output dimensions
             # and set it for next layer
-            if layer.image_size is not None:
+            if None not in layer.image_size:
                 output_shape = layer.get_dim('output')
                 image_size = output_shape[1:]
             num_channels = layer.num_output_channels

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -372,3 +372,31 @@ def test_convolutional_sequence_tied_biases_pushed_if_explicitly_set():
     cnn.allocate()
     assert [child.tied_biases for child in cnn.children
             if isinstance(child, Convolutional)]
+
+
+def test_convolutional_sequence_with_no_input_size():
+    # suppose x is outputted by some RNN
+    x = tensor.tensor4('x')
+    filter_size = (1, 1)
+    num_filters = 2
+    num_channels = 1
+    pooling_size = (1, 1)
+    conv = Convolutional(filter_size, num_filters, tied_biases=False,
+                         weights_init=Constant(1.), biases_init=Constant(1.))
+    act = Rectifier()
+    pool = MaxPooling(pooling_size)
+
+    bad_seq = ConvolutionalSequence([conv, act, pool], num_channels,
+                                    tied_biases=False)
+    assert_raises_regexp(ValueError, 'Cannot infer bias size \S+',
+                         bad_seq.initialize)
+
+    seq = ConvolutionalSequence([conv, act, pool], num_channels,
+                                tied_biases=True)
+    try:
+        seq.initialize()
+        out = seq.apply(x)
+    except TypeError:
+        assert False, "This should have succeeded"
+
+    assert out.ndim == 4


### PR DESCRIPTION
`ConvolutionalSequence` breaks when using it with layers that don't have the image size specified. The reason is due to a missing `None`-check (prior to setting the image size for a layer) and a `None`-check that checks whether the image size is `None`, whereas the `Convolutional` and `Pooling` classes both use `tuple`s of `None`.