### PR TITLE
Fix Pooling output dimensions w/ unspecified input dimensions

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -335,7 +335,7 @@ class Pooling(Initializable, Feedforward):
         if name == 'input_':
             return self.input_dim
         if name == 'output':
-            if None in self.input_dim[-2:]:
+            if self.input_dim[-2:] == (None, None):
                 # if input dimensions are unspecified, return similarly
                 # unspecified output dimensions (Theano's Pool.out_shape()
                 # won't take Nones)

--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -335,9 +335,15 @@ class Pooling(Initializable, Feedforward):
         if name == 'input_':
             return self.input_dim
         if name == 'output':
-            return tuple(Pool.out_shape(
-                self.input_dim, self.pooling_size, st=self.step,
-                ignore_border=self.ignore_border, padding=self.padding))
+            if None in self.input_dim[-2:]:
+                # if input dimensions are unspecified, return similarly
+                # unspecified output dimensions (Theano's Pool.out_shape()
+                # won't take Nones)
+                return self.input_dim
+            else:
+                return tuple(Pool.out_shape(
+                    self.input_dim, self.pooling_size, st=self.step,
+                    ignore_border=self.ignore_border, padding=self.padding))
 
     @property
     def num_output_channels(self):

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -487,4 +487,10 @@ def test_convolutional_sequence_with_no_input_size():
     except TypeError:
         assert False, "This should have succeeded"
 
+    assert seq.get_dim('output') == (num_filters, None, None)
     assert out.ndim == 4
+
+
+def test_pooling_with_no_input_size():
+    pool = MaxPooling((1, 1))
+    assert pool.get_dim('output') == (None, None, None)


### PR DESCRIPTION
The `Pooling` classes break when trying to provide output dimensions when the input dimensions are unspecified. This is particularly important for use with `ConvolutionalSequence`. This fixes that with a simple check on the input dimensions rather than passing the `None`s down to Theano's `Pool.out_shape()`, which won't handle them. Also included is a regression test, as well as an addition to the `ConvolutionalSequence` regression test.

Fixes #1048.
