### PR TITLE
Add links to different recurrent models

### DIFF
--- a/docs/rnn.rst
+++ b/docs/rnn.rst
@@ -294,3 +294,12 @@ implementation.
     When looking at a recurrent brick's documentation, keep in mind that the
     parameters to its ``apply`` method are explained in terms of a single
     iteration, *i.e.* with the assumption that ``iterate = False``.
+
+See Also
+--------
+
+- LSTM implementation: :class:`.bricks.recurrent.LSTM`
+- GRU implementation: :class:`.bricks.recurrent.GatedRecurrent`
+- Bidirectional RNNs: :class:`.bricks.recurrent.Bidirectional`
+- Deep recurrent networks (stacked RNNs):
+  :class:`.bricks.recurrent.RecurrentStack`


### PR DESCRIPTION
I noticed, that some people in the lab do not know about existence of bidirectional recurrent models or recurrent stack implemented in blocks. I hope, adding the link to RNN tutorial will help.

Also, Read the docs very bad at searching. For example, a search for [LSTM](http://blocks.readthedocs.org/en/latest/search.html?q=LSTM&check_keywords=yes&area=default#) doesn't really find it.