### PR TITLE
Speed up BatchNormalization training graphs

### DIFF
--- a/blocks/bricks/bn.py
+++ b/blocks/bricks/bn.py
@@ -190,8 +190,10 @@ class BatchNormalization(RNGMixin, Feedforward):
         if self.mean_only:
             stdev = tensor.ones_like(mean)
         else:
-            stdev = tensor.sqrt(tensor.var(input_, axis=axes, keepdims=True) +
-                                numpy.cast[theano.config.floatX](self.epsilon))
+            var = (tensor.sqr(input_).mean(axis=axes, keepdims=True) -
+                   tensor.sqr(mean))
+            eps = numpy.cast[theano.config.floatX](self.epsilon)
+            stdev = tensor.sqrt(var + eps)
             assert (stdev.broadcastable[1:] ==
                     self.population_stdev.broadcastable)
             add_role(stdev, BATCH_NORM_MINIBATCH_ESTIMATE)


### PR DESCRIPTION
Calculating mean and variance for `BatchNormalization` separately with `.mean()` and `.var()` seems to be causing an explosion in the number of `CAReduce` nodes.

This change takes the following approach:
 * Calculate mean with `.mean()`
 * Calculate variance by subtracting the square of the above-calculated mean from `tensor.sqr(input_).mean()`
 * Add stabilizing constant, take square root.

Apparently this was enough to get @rizar a ~33% speedup, such that full batch norm is now approximately as fast as mean-only batch norm.

@rizar promised to paste his profiles with/without into the comments tomorrow so we can preserve the rationale for this change.

@nouiz @lamblin you might be interested in this (from the perspective of making Theano be less dumb about `mean()` and `var()` calls on the same variable). @cooijmanstim also.