### PR TITLE
Fix serialization with protocol 0 on Python 3.

### DIFF
--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -611,6 +611,10 @@ def _mangle_parameter_name(parameter, name):
 
 
 def _unmangle_parameter_name(mangled_name):
+    if not isinstance(mangled_name, str):
+        # This fixes an issue with protocol 0 on Python 3 where
+        # 'mangled_name' is a bytes object, for some reason.
+        mangled_name = mangled_name.decode('utf8')
     if mangled_name.startswith('#1'):
         type_, context_name, name = mangled_name[2:].split('.', 2)
         if context_name == 'None':

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,6 +2,7 @@ import os
 import warnings
 import tarfile
 from pickle import PicklingError
+from io import BytesIO
 from tempfile import NamedTemporaryFile
 
 import numpy
@@ -159,3 +160,15 @@ def test_dump_and_add_to_dump():
         dump_and_add_to_dump(x, f, None, {'y': y})
     assert load(open(f.name, 'rb')) == x
     assert load(open(f.name, 'rb'), 'y') == y
+
+
+def test_protocol0_regression():
+    """Check for a regression where protocol 0 dumps fail on load."""
+    brick = Linear(5, 10)
+    brick.allocate()
+    buf = BytesIO()
+    dump(brick, buf, parameters=list(brick.parameters), protocol=0)
+    try:
+        load(buf)
+    except TypeError:
+        assert False  # Regression


### PR DESCRIPTION
Not sure why this was happening but this is a simple fix.