### PR TITLE
Handle adding children to kwargs appropriately if a subclass has already added children.

### DIFF
--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -325,9 +325,9 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
         self.energy_computer = energy_computer
 
         children = [self.state_transformers, attended_transformer,
-                    energy_computer] + kwargs.get('children', [])
-        super(SequenceContentAttention, self).__init__(children=children,
-                                                       **kwargs)
+                    energy_computer]
+        kwargs.setdefault('children', []).extend(children)
+        super(SequenceContentAttention, self).__init__(**kwargs) 
 
     def _push_allocation_config(self):
         self.state_transformers.input_dims = self.state_dims
@@ -576,8 +576,8 @@ class AttentionRecurrent(AbstractAttentionRecurrent, Initializable):
             if name in self.attention.take_glimpses.inputs]
 
         children = [self.transition, self.attention, self.distribute]
-        children += kwargs.get('children', [])
-        super(AttentionRecurrent, self).__init__(children=children, **kwargs)
+        kwargs.setdefault('children', []).extend(children)
+        super(AttentionRecurrent, self).__init__(**kwargs)
 
     def _push_allocation_config(self):
         self.attention.state_dims = self.transition.get_dims(

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -278,8 +278,9 @@ class SimpleRecurrent(BaseRecurrent, Initializable):
     @lazy(allocation=['dim'])
     def __init__(self, dim, activation, **kwargs):
         self.dim = dim
-        children = [activation] + kwargs.get('children', [])
-        super(SimpleRecurrent, self).__init__(children=children, **kwargs)
+        children = [activation]
+        kwargs.setdefault('children', []).extend(children)
+        super(SimpleRecurrent, self).__init__(**kwargs)
 
     @property
     def W(self):
@@ -384,9 +385,9 @@ class LSTM(BaseRecurrent, Initializable):
         self.activation = activation
         self.gate_activation = gate_activation
 
-        children = ([self.activation, self.gate_activation] +
-                    kwargs.get('children', []))
-        super(LSTM, self).__init__(children=children, **kwargs)
+        children = [self.activation, self.gate_activation]
+        kwargs.setdefault('children', []).extend(children)
+        super(LSTM, self).__init__(**kwargs)
 
     def get_dim(self, name):
         if name == 'inputs':
@@ -532,8 +533,9 @@ class GatedRecurrent(BaseRecurrent, Initializable):
         self.activation = activation
         self.gate_activation = gate_activation
 
-        children = [activation, gate_activation] + kwargs.get('children', [])
-        super(GatedRecurrent, self).__init__(children=children, **kwargs)
+        children = [activation, gate_activation]
+        kwargs.setdefault('children', []).extend(children)
+        super(GatedRecurrent, self).__init__(**kwargs)
 
     @property
     def state_to_state(self):
@@ -644,8 +646,8 @@ class Bidirectional(Initializable):
         children = [copy.deepcopy(prototype) for _ in range(2)]
         children[0].name = 'forward'
         children[1].name = 'backward'
-        children += kwargs.get('children', [])
-        super(Bidirectional, self).__init__(children=children, **kwargs)
+        kwargs.setdefault('children', []).extend(children)
+        super(Bidirectional, self).__init__(**kwargs)
 
     @application
     def apply(self, *args, **kwargs):

--- a/blocks/bricks/sequence_generators.py
+++ b/blocks/bricks/sequence_generators.py
@@ -155,9 +155,8 @@ class BaseSequenceGenerator(Initializable):
         self.fork = fork
 
         children = [self.readout, self.fork, self.transition]
-        children += kwargs.get('children', [])
-        super(BaseSequenceGenerator, self).__init__(children=children,
-                                                    **kwargs)
+        kwargs.setdefault('children', []).extend(children)
+        super(BaseSequenceGenerator, self).__init__(**kwargs)
 
     @property
     def _state_names(self):
@@ -529,8 +528,9 @@ class Readout(AbstractReadout):
         self.merged_dim = merged_dim
 
         children = [self.emitter, self.feedback_brick, self.merge,
-                    self.post_merge] + kwargs.get('children', [])
-        super(Readout, self).__init__(children=children, **kwargs)
+                    self.post_merge]
+        kwargs.setdefault('children', []).extend(children)
+        super(Readout, self).__init__(**kwargs)
 
     def _push_allocation_config(self):
         self.emitter.readout_dim = self.get_dim('readouts')
@@ -688,8 +688,9 @@ class SoftmaxEmitter(AbstractEmitter, Initializable, Random):
     def __init__(self, initial_output=0, **kwargs):
         self.initial_output = initial_output
         self.softmax = NDimensionalSoftmax()
-        children = [self.softmax] + kwargs.get('children', [])
-        super(SoftmaxEmitter, self).__init__(children=children, **kwargs)
+        children = [self.softmax]
+        kwargs.setdefault('children', []).extend(children)
+        super(SoftmaxEmitter, self).__init__(**kwargs)
 
     @application
     def probs(self, readouts):
@@ -749,8 +750,9 @@ class LookupFeedback(AbstractFeedback, Initializable):
         self.feedback_dim = feedback_dim
 
         self.lookup = LookupTable(num_outputs, feedback_dim)
-        children = [self.lookup] + kwargs.get('children', [])
-        super(LookupFeedback, self).__init__(children=children, **kwargs)
+        children = [self.lookup]
+        kwargs.setdefault('children', []).extend(children)
+        super(LookupFeedback, self).__init__(**kwargs)
 
     def _push_allocation_config(self):
         self.lookup.length = self.num_outputs
@@ -791,9 +793,9 @@ class FakeAttentionRecurrent(AbstractAttentionRecurrent, Initializable):
         self.context_names = transition.apply.contexts
         self.glimpse_names = []
 
-        children = [self.transition] + kwargs.get('children', [])
-        super(FakeAttentionRecurrent, self).__init__(children=children,
-                                                     **kwargs)
+        children = [self.transition]
+        kwargs.setdefault('children', []).extend(children)
+        super(FakeAttentionRecurrent, self).__init__(**kwargs)
 
     @application
     def apply(self, *args, **kwargs):

--- a/blocks/bricks/sequences.py
+++ b/blocks/bricks/sequences.py
@@ -27,8 +27,8 @@ class Sequence(Brick):
         seen = set()
         children = [app.brick for app in application_methods
                     if not (app.brick in seen or seen.add(app.brick))]
-        children += kwargs.get('children', [])
-        super(Sequence, self).__init__(children=children, **kwargs)
+        kwargs.setdefault('children', []).extend(children)
+        super(Sequence, self).__init__(**kwargs)
 
     @application
     def apply(self, *args):

--- a/blocks/bricks/simple.py
+++ b/blocks/bricks/simple.py
@@ -206,8 +206,9 @@ class LinearMaxout(Initializable, Feedforward):
     def __init__(self, input_dim, output_dim, num_pieces, **kwargs):
         self.linear = Linear()
         self.maxout = Maxout()
-        children = [self.linear, self.maxout] + kwargs.get('children', [])
-        super(LinearMaxout, self).__init__(children=children, **kwargs)
+        children = [self.linear, self.maxout]
+        kwargs.setdefault('children', []).extend(children)
+        super(LinearMaxout, self).__init__(**kwargs)
 
         self.input_dim = input_dim
         self.output_dim = output_dim

--- a/docs/create_your_own_brick.rst
+++ b/docs/create_your_own_brick.rst
@@ -213,8 +213,8 @@ specify the ``input_dim`` of ``brick2`` directly at its creation.
     ...         self.brick1 = brick1
     ...         self.brick2 = brick2
     ...         children = [self.brick1, self.brick2]
-    ...         children += kwargs.get('children', [])
-    ...         super(Feedforward, self).__init__(children=children, **kwargs)
+    ...         kwargs.setdefault('children', []).extend(children)
+    ...         super(Feedforward, self).__init__(**kwargs)
     ...
     ...     @property
     ...     def input_dim(self):
@@ -376,9 +376,8 @@ One can also create the brick using :class:`Linear` children bricks, which
     ...         self.linear2 = Linear(input_dim2, output_dim2,
     ...                               use_bias=False, **kwargs)
     ...         children = [self.linear1, self.linear2]
-    ...         children += kwargs.get('children', [])
-    ...         super(ParallelLinear2, self).__init__(children=children,
-    ...                                               **kwargs)
+    ...         kwargs.setdefault('children', []).extend(children)
+    ...         super(ParallelLinear2, self).__init__(**kwargs)
     ...
     ...     @application(inputs=['input1_', 'input2_'], outputs=['output1',
     ...         'output2'])


### PR DESCRIPTION
If we use `kwargs.get('children', [])` and initialize the super class by 

```
super(Class2, self).__init__(children=children,  **kwargs)
```
Then it will result the following error if the `kwargs` contains children, because we have pass the children twice.
```
    super(Class2, self).__init__(children=children, **kwargs)
TypeError: __init__() got multiple values for keyword argument 'children'
```

I'm not sure why using `kwargs.get('children', [])` in #1029 . In my opinion, we should use  `kwargs.pop('children', [])`.
