### PR TITLE
GradientDescent: refactoring, enhancements, bug fixes

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -71,149 +71,85 @@ Blocks didn't find all the sources ({sources}) of the training dataset \
 that match the names of the Theano variables ({variables})."""
 
 
-class GradientDescent(TrainingAlgorithm):
-    """A base class for all gradient descent algorithms.
+determinism_error = """Cannot infer parameter list in a fixed order.
 
-    By "gradient descent" we mean a training algorithm of the following
-    form:
+Because dictionaries are unordered (and Python uses randomized hashing, \
+which can change the iteration order over the same dictionary from one \
+interpreter session to the next), Blocks cannot infer the parameters list \
+from a plain dictionary of gradients in an order that is reproducible \
+across interpreter sessions; please either specify the parameters \
+explicitly or pass gradients as an OrderedDict (though exercise care in \
+constructing that OrderedDict, as an OrderedDict \ created by iterating \
+over an unordered iterable (e.g. a dict) will still \ have an arbitrary \
+and unpredictable order that could cause problems with \
+reproducibility)."""
 
-    .. code-block::  python
 
-        for batch in data:
-            steps = step_rule.compute_steps(parameters,
-                                            gradients_wr_parameters)
-            for parameter in parameters:
-                parameter -= steps[parameter]
-
-    Note, that the step is *subtracted, not added*! This is done in order
-    to make step rule chaining possible.
+class UpdatesAlgorithm(TrainingAlgorithm):
+    """Base class for algorithms that use Theano functions with updates.
 
     Parameters
     ----------
-    cost : :class:`~tensor.TensorVariable`, optional
-        The objective to be minimized.
-    parameters : list of :class:`~tensor.TensorSharedVariable`, optional
-        The parameters to be tuned. If not provided, inferred from the
-        keys of `gradients`.
-    step_rule : instance of :class:`StepRule`, optional
-        An object encapsulating most of the algorithm's logic. Its
-        `compute_steps` method is called to get Theano expression for
-        steps.  Note, that the step rule might have a state, e.g. to
-        remember a weighted sum of gradients from previous steps like it is
-        done in gradient descent with momentum. If ``None``, an instance of
-        :class:`Scale` is created.
-    gradients : dict, optional
-        A dictionary mapping a parameter to an expression for the cost's
-        gradient with respect to the parameter. If ``None``, the gradient
-        are taken automatically using :func:`theano.gradient.grad`.
-    known_grads : dict, optional
-        A passthrough to `theano.tensor.grad`'s `known_grads` argument.
-        Useful when you know the [approximate] gradients of some
-        sub-expressions and would like Theano to use that information
-        to compute parameter gradients. Only makes sense when `gradients`
-        is `None`.
-    consider_constant : list, optional
-        A passthrough to `theano.tensor.grad`'s `consider_constant`
-        argument.  A list of expressions through which gradients will not
-        be backpropagated. Only makes sense when `gradients` is `None`.
-    on_unused_sources : str, one of 'raise' (default), 'ignore', 'warn'
-        Controls behavior when not all sources are used.
+    updates : list of tuples or :class:`~collections.OrderedDict`
+        The updates that should be performed.
     theano_func_kwargs : dict, optional
         A passthrough to `theano.function` for additional arguments.
         Useful for passing `profile` or `mode` arguments to the theano
         function that will be compiled for the algorithm.
+    on_unused_sources : str, one of 'raise' (default), 'ignore', 'warn'
+        Controls behavior when not all sources in a batch are used
+        (i.e. there is no variable with a matching name in the inputs
+        of the computational graph of the updates).
 
     Attributes
     ----------
-    gradients : dict
-        The gradient dictionary.
-    step_rule : instance of :class:`StepRule`
-        The step rule.
     updates : list of :class:`~tensor.TensorSharedVariable` updates
         Updates to be done for every batch. It is required that the
         updates are done using the old values of optimized parameters.
 
-    Notes
-    -----
-    Changing `updates` attribute or calling `add_updates` after
-    the `initialize` method is called will have no effect.
-
-    .. todo::
-
-       Some shared variables are not parameters (e.g. those created by
-       random streams).
-
-    .. todo::
-
-       Due to a rather premature status of the :class:`ComputationGraph`
-       class the parameter used only inside scans are not fetched
-       currently.
-
     """
-    def __init__(self, cost=None, parameters=None, step_rule=None,
-                 gradients=None, known_grads=None, consider_constant=None,
-                 on_unused_sources='raise', theano_func_kwargs=None, **kwargs):
-        super(GradientDescent, self).__init__(**kwargs)
-        # Set initial values for cost, parameters, gradients.
-        self.cost = cost
-        self._updates = []
-        self.parameters = parameters
-        self.gradients = gradients
-
-        # If we don't have gradients, we'll need to infer them from the
-        # cost and the parameters, both of which must not be None.
-        if not self.gradients:
-            if self.cost is None:
-                raise ValueError("can't infer gradients; no cost specified")
-            elif self.parameters is None or len(self.parameters) == 0:
-                raise ValueError("can't infer gradients; "
-                                 "no parameters specified")
-            self.inputs = ComputationGraph(cost).inputs
-            logger.info("Taking the cost gradient")
-            self.gradients = dict(
-                equizip(self.parameters, tensor.grad(
-                    self.cost, self.parameters,
-                    known_grads=known_grads,
-                    consider_constant=consider_constant)))
-            logger.info("The cost gradient computation graph is built")
-        else:
-            # If we have gradients, we get parameters from that.
-            # If you're specifying both then something is screwy.
-            if self.parameters is not None:
-                logger.warning('{} received both gradients and parameters '
-                               'arguments; using parameters deduced from '
-                               'gradients')
-            self.parameters = list(gradients.keys())
-            self.inputs = ComputationGraph(gradients.values()).inputs
-            if known_grads:
-                raise ValueError("known_grads has no effect when gradients "
-                                 "are passed in")
-            if consider_constant is not None:
-                raise ValueError("consider_constant has no effect when "
-                                 "gradients are passed in")
-        self.step_rule = step_rule if step_rule else Scale()
-
-        self.total_gradient_norm = l2_norm(
-            self.gradients.values()).copy(name="total_gradient_norm")
-        self.steps, self.step_rule_updates = (
-            self.step_rule.compute_steps(self.gradients))
-        self.total_step_norm = l2_norm(
-            self.steps.values()).copy(name="total_step_norm")
-        self.on_unused_sources = on_unused_sources
+    def __init__(self, updates=None, theano_func_kwargs=None,
+                 on_unused_sources='raise', **kwargs):
+        self.updates = [] if updates is None else updates
         self.theano_func_kwargs = (theano_func_kwargs if theano_func_kwargs
                                    is not None else dict())
+        self.on_unused_sources = on_unused_sources
+        super(UpdatesAlgorithm, self).__init__(**kwargs)
 
     def initialize(self):
         logger.info("Initializing the training algorithm")
-        # Note: the gradients are computed in the same order in which
-        # the parameters were given. Keep it like that to ensure
-        # reproducibility.
-        for parameter in self.parameters:
-            self.updates.append((parameter, parameter - self.steps[parameter]))
-        self.updates += self.step_rule_updates
+        update_values = [new_value for _, new_value in self.updates]
+        logger.debug("Inferring graph inputs...")
+        self.inputs = ComputationGraph(update_values).inputs
+        logger.debug("Compiling training function...")
         self._function = theano.function(
             self.inputs, [], updates=self.updates, **self.theano_func_kwargs)
         logger.info("The training algorithm is initialized")
+
+    @property
+    def updates(self):
+        return self._updates
+
+    @updates.setter
+    def updates(self, value):
+        self._updates = value
+
+    def add_updates(self, updates):
+        """Add updates to the training process.
+
+        The updates will be done _before_ the parameters are changed.
+
+        Parameters
+        ----------
+        updates : list of tuples or :class:`~collections.OrderedDict`
+            The updates to add.
+
+        """
+        if isinstance(updates, OrderedDict):
+            updates = list(updates.items())
+        if not isinstance(updates, list):
+            raise ValueError
+        self.updates.extend(updates)
 
     def _validate_source_names(self, batch):
         in_names = [v.name for v in self.inputs]
@@ -247,30 +183,169 @@ class GradientDescent(TrainingAlgorithm):
         ordered_batch = [batch[v.name] for v in self.inputs]
         self._function(*ordered_batch)
 
-    @property
-    def updates(self):
-        return self._updates
 
-    @updates.setter
-    def updates(self, value):
-        self._updates = value
+class GradientDescent(UpdatesAlgorithm):
+    """A base class for all gradient descent algorithms.
 
-    def add_updates(self, updates):
-        """Add updates to the training process.
+    By "gradient descent" we mean a training algorithm of the following
+    form:
 
-        The updates will be done _before_ the parameters are changed.
+    .. code-block::  python
 
-        Parameters
-        ----------
-        updates : list of tuples or :class:`~collections.OrderedDict`
-            The updates to add.
+        for batch in data:
+            steps = step_rule.compute_steps(parameters,
+                                            gradients_wr_parameters)
+            for parameter in parameters:
+                parameter -= steps[parameter]
 
-        """
-        if isinstance(updates, OrderedDict):
-            updates = list(updates.items())
-        if not isinstance(updates, list):
-            raise ValueError
-        self.updates.extend(updates)
+    Note, that the step is *subtracted, not added*! This is done in order
+    to make step rule chaining possible.
+
+    Parameters
+    ----------
+    cost : :class:`~tensor.TensorVariable`, optional
+        The objective to be minimized.
+    parameters : list of :class:`~tensor.TensorSharedVariable`, optional
+        The parameters to be tuned. If not provided, inferred from the
+        keys of `gradients` (in which case `gradients` *must* be an
+        `OrderedDict`).
+    step_rule : instance of :class:`StepRule`, optional
+        An object encapsulating most of the algorithm's logic. Its
+        `compute_steps` method is called to get Theano expression for
+        steps.  Note, that the step rule might have a state, e.g. to
+        remember a weighted sum of gradients from previous steps like it is
+        done in gradient descent with momentum. If ``None``, an instance of
+        :class:`Scale` is created.
+    gradients : OrderedDict, optional
+        A dictionary mapping a parameter to an expression for the cost's
+        gradient with respect to the parameter. If ``None``, the gradient
+        are taken automatically using :func:`theano.gradient.grad`.
+    known_grads : dict, optional
+        A passthrough to `theano.tensor.grad`'s `known_grads` argument.
+        Useful when you know the [approximate] gradients of some
+        sub-expressions and would like Theano to use that information
+        to compute parameter gradients. Only makes sense when `gradients`
+        is `None`.
+    consider_constant : list, optional
+        A passthrough to `theano.tensor.grad`'s `consider_constant`
+        argument.  A list of expressions through which gradients will not
+        be backpropagated. Only makes sense when `gradients` is `None`.
+
+    Attributes
+    ----------
+    gradients : OrderedDict
+        The gradient dictionary.
+    step_rule : instance of :class:`StepRule`
+        The step rule.
+
+    Notes
+    -----
+    Changing `updates` attribute or calling `add_updates` after
+    the `initialize` method is called will have no effect.
+
+    `gradients` must be an `OrderedDict` if `parameters` is unspecified
+    because ordinary dictionaries have an unpredictable iteration
+    order due to hash randomization (which is enabled by default since
+    versions 2.7.3 and 3.2.3 of Python). This source of variability,
+    when combined with Theano's heuristic graph optimizations, can cause
+    serious reproducibility issues.
+
+    .. todo::
+
+       Some shared variables are not parameters (e.g. those created by
+       random streams).
+
+    .. todo::
+
+       Due to a rather premature status of the :class:`ComputationGraph`
+       class the parameter used only inside scans are not fetched
+       currently.
+
+    """
+    def __init__(self, cost=None, parameters=None, step_rule=None,
+                 gradients=None, known_grads=None, consider_constant=None,
+                 **kwargs):
+        # Set initial values for cost, parameters, gradients.
+        self.cost = cost
+        self.parameters = parameters
+        self.gradients = gradients
+
+        # If we don't have gradients, we'll need to infer them from the
+        # cost and the parameters, both of which must not be None.
+        if not self.gradients:
+            if self.cost is None:
+                raise ValueError("can't infer gradients; no cost specified")
+            elif self.parameters is None or len(self.parameters) == 0:
+                raise ValueError("can't infer gradients; "
+                                 "no parameters specified")
+
+            # While this strictly speaking could be a dict and not an
+            # OrderedDict (because we iterate over it in the order of
+            # self.parameters), this guards a little bit against
+            # nondeterminism introduced by future refactoring.
+            logger.info("Taking the cost gradient")
+            self.gradients = OrderedDict(
+                equizip(self.parameters, tensor.grad(
+                    self.cost, self.parameters,
+                    known_grads=known_grads,
+                    consider_constant=consider_constant)))
+            logger.info("The cost gradient computation graph is built")
+        else:
+            if self.parameters is None and isinstance(gradients, OrderedDict):
+                # If the dictionary is ordered, it's safe to use the keys
+                # as they have a deterministic order.
+                self.parameters = list(self.gradients.keys())
+            elif self.parameters is not None:
+                # If parameters and gradients.keys() don't match we can
+                # try to recover if gradients is ordered.
+                if set(self.parameters) != set(self.gradients.keys()):
+                    logger.warn("Specified parameters list does not match "
+                                "keys in provided gradient dictionary; "
+                                "using parameters inferred from gradients")
+                    if not isinstance(self.gradients, OrderedDict):
+                        raise ValueError(determinism_error)
+                    self.parameters = list(self.gradients.keys())
+            else:
+                # self.parameters is not None, and gradients isn't
+                # an OrderedDict. We can't do anything safe.
+                raise ValueError(determinism_error)
+            if known_grads:
+                raise ValueError("known_grads has no effect when gradients "
+                                 "are passed in")
+            if consider_constant is not None:
+                raise ValueError("consider_constant has no effect when "
+                                 "gradients are passed in")
+
+        # The order in which the different gradient terms appears
+        # here matters, as floating point addition is non-commutative (and
+        # Theano's graph optimizations are not order-independent).
+        # This is why we do not use .values().
+        gradient_values = [self.gradients[p] for p in self.parameters]
+        self.total_gradient_norm = (l2_norm(gradient_values)
+                                    .copy(name="total_gradient_norm"))
+
+        self.step_rule = step_rule if step_rule else Scale()
+        logger.debug("Computing parameter steps...")
+        self.steps, self.step_rule_updates = (
+            self.step_rule.compute_steps(self.gradients))
+
+        # Same as gradient_values above: the order may influence a
+        # bunch of things, so enforce a consistent one (don't use
+        # .values()).
+        step_values = [self.steps[p] for p in self.parameters]
+        self.total_step_norm = (l2_norm(step_values)
+                                .copy(name="total_step_norm"))
+
+        # Once again, iterating on gradients may not be deterministically
+        # ordered if it is not an OrderedDict. We add the updates here in
+        # the order specified in self.parameters. Keep it this way to
+        # maintain reproducibility.
+        kwargs.setdefault('updates', []).extend(
+            itertools.chain(((parameter, parameter - self.steps[parameter])
+                             for parameter in self.parameters),
+                            self.step_rule_updates)
+        )
+        super(GradientDescent, self).__init__(**kwargs)
 
 
 @add_metaclass(ABCMeta)

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -204,7 +204,7 @@ class GradientDescent(UpdatesAlgorithm):
     Parameters
     ----------
     cost : :class:`~tensor.TensorVariable`, optional
-        The objective to be minimized.
+        The objective to be minimized. Unused if `gradients` is specified.
     parameters : list of :class:`~tensor.TensorSharedVariable`, optional
         The parameters to be tuned. If not provided, inferred from the
         keys of `gradients` (in which case `gradients` *must* be an
@@ -291,6 +291,10 @@ class GradientDescent(UpdatesAlgorithm):
                     consider_constant=consider_constant)))
             logger.info("The cost gradient computation graph is built")
         else:
+            if cost is not None:
+                logger.warning(('{}: gradients already specified directly; '
+                                'cost is unused.'
+                                .format(self.__class__.__name__)))
             if self.parameters is None and isinstance(gradients, OrderedDict):
                 # If the dictionary is ordered, it's safe to use the keys
                 # as they have a deterministic order.

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -107,6 +107,11 @@ class UpdatesAlgorithm(TrainingAlgorithm):
         Updates to be done for every batch. It is required that the
         updates are done using the old values of optimized parameters.
 
+    Notes
+    -----
+    Changing `updates` attribute or calling `add_updates` after
+    the `initialize` method is called will have no effect.
+
     """
     def __init__(self, updates=None, theano_func_kwargs=None,
                  on_unused_sources='raise', **kwargs):
@@ -242,6 +247,10 @@ class GradientDescent(UpdatesAlgorithm):
     -----
     Changing `updates` attribute or calling `add_updates` after
     the `initialize` method is called will have no effect.
+
+    If a cost and parameters are provided, gradients are taken immediately
+    upon construction, and changes to these attributes after construction
+    will have no effect.
 
     `gradients` must be an `OrderedDict` if `parameters` is unspecified
     because ordinary dictionaries have an unpredictable iteration

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -259,17 +259,6 @@ class GradientDescent(UpdatesAlgorithm):
     when combined with Theano's heuristic graph optimizations, can cause
     serious reproducibility issues.
 
-    .. todo::
-
-       Some shared variables are not parameters (e.g. those created by
-       random streams).
-
-    .. todo::
-
-       Due to a rather premature status of the :class:`ComputationGraph`
-       class the parameter used only inside scans are not fetched
-       currently.
-
     """
     def __init__(self, cost=None, parameters=None, step_rule=None,
                  gradients=None, known_grads=None, consider_constant=None,

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -61,9 +61,9 @@ variable_mismatch_error = """
 Blocks tried to match the sources ({sources}) of the training dataset to \
 the names of the Theano variables ({variables}), but failed to do so. \
 If you want to train on a subset of the sources that your dataset provides, \
-pass the `sources` keyword argument to its constructor. Or pass \
-on_unused_sources='warn' or on_unused_sources='ignore' to \
-the GradientDescent algorithm."""
+pass the `sources` keyword argument to its constructor, use the \
+FilterSources transformer provided by Fuel, or pass on_unused_sources='warn' \
+or on_unused_sources='ignore' to the GradientDescent algorithm."""
 
 source_missing_error = """
 
@@ -79,8 +79,8 @@ interpreter session to the next), Blocks cannot infer the parameters list \
 from a plain dictionary of gradients in an order that is reproducible \
 across interpreter sessions; please either specify the parameters \
 explicitly or pass gradients as an OrderedDict (though exercise care in \
-constructing that OrderedDict, as an OrderedDict \ created by iterating \
-over an unordered iterable (e.g. a dict) will still \ have an arbitrary \
+constructing that OrderedDict, as an OrderedDict created by iterating \
+over an unordered iterable (e.g. a dict) will still have an arbitrary \
 and unpredictable order that could cause problems with \
 reproducibility)."""
 

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -4,7 +4,7 @@ import logging
 import theano
 
 from blocks.extensions import SimpleExtension, TrainingExtension
-from blocks.algorithms import GradientDescent
+from blocks.algorithms import UpdatesAlgorithm
 from blocks.monitoring.aggregation import MonitoredQuantity, take_last
 from blocks.monitoring.evaluators import (
     AggregationBuffer, MonitoredQuantityBuffer, DatasetEvaluator)
@@ -122,7 +122,7 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
     update.
 
     Requires the training algorithm to be an instance of
-    :class:`.GradientDescent`.
+    :class:`.UpdatesAlgorithm`.
 
     """
     def __init__(self, variables, **kwargs):
@@ -164,7 +164,7 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
         data, args = self.parse_args(callback_name, args)
         if callback_name == 'before_training':
             if not isinstance(self.main_loop.algorithm,
-                              GradientDescent):
+                              UpdatesAlgorithm):
                 raise ValueError
             self.main_loop.algorithm.add_updates(
                 self._variables.accumulation_updates)

--- a/blocks/extensions/monitoring.py
+++ b/blocks/extensions/monitoring.py
@@ -4,7 +4,7 @@ import logging
 import theano
 
 from blocks.extensions import SimpleExtension, TrainingExtension
-from blocks.algorithms import DifferentiableCostMinimizer
+from blocks.algorithms import GradientDescent
 from blocks.monitoring.aggregation import MonitoredQuantity, take_last
 from blocks.monitoring.evaluators import (
     AggregationBuffer, MonitoredQuantityBuffer, DatasetEvaluator)
@@ -122,7 +122,7 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
     update.
 
     Requires the training algorithm to be an instance of
-    :class:`.DifferentiableCostMinimizer`.
+    :class:`.GradientDescent`.
 
     """
     def __init__(self, variables, **kwargs):
@@ -164,7 +164,7 @@ class TrainingDataMonitoring(SimpleExtension, MonitoringExtension):
         data, args = self.parse_args(callback_name, args)
         if callback_name == 'before_training':
             if not isinstance(self.main_loop.algorithm,
-                              DifferentiableCostMinimizer):
+                              GradientDescent):
                 raise ValueError
             self.main_loop.algorithm.add_updates(
                 self._variables.accumulation_updates)

--- a/blocks/graph/__init__.py
+++ b/blocks/graph/__init__.py
@@ -70,7 +70,7 @@ class ComputationGraph(object):
     def __init__(self, outputs):
         if isinstance(outputs, Variable):
             outputs = [outputs]
-        self.outputs = outputs
+        self.outputs = list(outputs)
         self._get_variables()
         self._has_inputs = {}
 

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -7,7 +7,7 @@ from blocks.config import config
 from blocks.log import BACKENDS
 from blocks.utils import reraise_as, unpack, change_recursion_limit
 from blocks.utils.profile import Profile, Timer
-from blocks.algorithms import DifferentiableCostMinimizer
+from blocks.algorithms import GradientDescent
 from blocks.extensions import CallbackName
 from blocks.model import Model
 
@@ -152,7 +152,7 @@ class MainLoop(object):
 
         # Sanity check for the most common case
         if (self._model and isinstance(self._model, Model) and
-                isinstance(self.algorithm, DifferentiableCostMinimizer)):
+                isinstance(self.algorithm, GradientDescent)):
             if not (set(self._model.get_parameter_dict().values()) ==
                     set(self.algorithm.parameters)):
                 logger.warning("different parameters for model and algorithm")

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -114,6 +114,16 @@ def test_gradient_descent_multiple_initialize():
     assert_allclose(W.get_value(), -0.5 * W_start_value)
 
 
+def test_gradient_descent_finds_inputs_additional_updates():
+    W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
+    n = shared_floatx(1)
+    m = tensor.scalar('m')
+    algorithm = GradientDescent(gradients=OrderedDict([(W, W + 1)]))
+    algorithm.add_updates([(n, n + m)])
+    algorithm.initialize()
+    assert m in algorithm.inputs
+
+
 def test_gradient_descent_parameters_inferred():
     W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
     algorithm = GradientDescent(gradients=OrderedDict([(W, W + 1)]))

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -96,6 +96,24 @@ def test_gradient_descent_with_gradients():
     assert_allclose(W.get_value(), -0.5 * W_start_value)
 
 
+def test_gradient_descent_multiple_initialize():
+    W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
+    W_start_value = W.get_value()
+    cost = tensor.sum(W ** 2)
+    gradients = OrderedDict()
+    gradients[W] = tensor.grad(cost, W)
+
+    algorithm = GradientDescent(gradients=gradients)
+    algorithm.step_rule.learning_rate.set_value(0.75)
+    algorithm.initialize()
+    algorithm.initialize()
+    algorithm.initialize()
+
+    assert len(algorithm.updates) == 1
+    algorithm.process_batch(dict())
+    assert_allclose(W.get_value(), -0.5 * W_start_value)
+
+
 def test_gradient_descent_parameters_inferred():
     W = shared_floatx(numpy.array([[1, 2], [3, 4]]))
     algorithm = GradientDescent(gradients=OrderedDict([(W, W + 1)]))


### PR DESCRIPTION
A refactoring plus a variety of improvements and potential bug fixes to `GradientDescent`.

* `DifferentiableCostMinimizer` is gone in favour of a more useful base class, `UpdatesAlgorithm`, which just takes a list of updates and compiles a Theano function for you (as suggested/concurred by @rizar [here](https://github.com/mila-udem/blocks/issues/735#issuecomment-116605243)). (#735)
* `GradientDescent` now no longer requires a `cost` argument, which was superfluous but still if `gradients`. (#919) This also means inputs are now always inferred from the computation graph of the *updates* and not of the *cost*, which is a bit more robust I think (particularly to the case where additional updates may need a source that the training updates don't, e.g. #938)
* `GradientDescent` issues warnings if you've specified gradients as well as a cost (that the cost does nothing in this case), and if you pass parameters and gradients that don't match.
* `GradientDescent` now raises **errors** in situations where `gradients` being a dict (as opposed to an OrderedDict) could lead to non-determinism across runs due to randomized hashing/dictionary iteration order.
* The computation of `GradientDescent`''s `total_step_norm` and `total_gradient_norm` now sums the terms in a fixed order based on `self.parameters`, which should remove a potential source of non-determinism in those computations.
* As a happy by-product of `UpdatesAlgorithm`, `GradientDescent` now accepts an `updates` keyword argument for directly specifying additional updates at construction (#1023).
* I noticed that this fixes #870 and #938, almost by accident, so I added tests for them.

Fixes #735.
Fixes #919.
Fixes #1023.
Fixes #938.
Fixes #870.