### PR TITLE
Fixes #1086: use six.wraps insted of functools

### DIFF
--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -1,7 +1,7 @@
 import inspect
 from abc import ABCMeta
 from collections import OrderedDict
-from functools import wraps
+from six import wraps
 from operator import attrgetter
 from types import MethodType
 

--- a/blocks/bricks/recurrent.py
+++ b/blocks/bricks/recurrent.py
@@ -2,7 +2,7 @@
 import copy
 import inspect
 import logging
-from functools import wraps
+from six import wraps
 
 from picklable_itertools.extras import equizip
 import numpy

--- a/blocks/utils/testing.py
+++ b/blocks/utils/testing.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from functools import wraps
+from six import wraps
 from importlib import import_module
 from unittest.case import SkipTest
 


### PR DESCRIPTION
Replaces imports of `functools.wraps` with imports of `six.wraps` for python2 and 3 compatibility.