### PR TITLE
Unique path for all parameters

### DIFF
--- a/blocks/bricks/attention.py
+++ b/blocks/bricks/attention.py
@@ -327,7 +327,7 @@ class SequenceContentAttention(GenericSequenceAttention, Initializable):
         children = [self.state_transformers, attended_transformer,
                     energy_computer]
         kwargs.setdefault('children', []).extend(children)
-        super(SequenceContentAttention, self).__init__(**kwargs) 
+        super(SequenceContentAttention, self).__init__(**kwargs)
 
     def _push_allocation_config(self):
         self.state_transformers.input_dims = self.state_dims

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -15,6 +15,8 @@ from blocks.roles import add_role, PARAMETER, INPUT, OUTPUT
 from blocks.utils import dict_union, pack, repr_attrs, reraise_as, unpack
 from blocks.utils.containers import AnnotatingList
 
+BRICK_PATH_DELIMITER = '/'
+
 
 def create_unbound_method(func, cls):
     """Create an unbounded method from a function and a class.
@@ -772,6 +774,14 @@ class Brick(Annotation):
             return parent.get_unique_path() + [self]
         else:
             return [self]
+
+    def get_hierarchical_name(self, parameter, delimiter=BRICK_PATH_DELIMITER):
+        """Return hierarhical name for a parameter."""
+        return '{}.{}'.format(
+            delimiter.join(
+                [""] + [brick.name for brick in
+                        self.get_unique_path()]),
+            parameter.name)
 
 
 def args_to_kwargs(args, f):

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -776,7 +776,17 @@ class Brick(Annotation):
             return [self]
 
     def get_hierarchical_name(self, parameter, delimiter=BRICK_PATH_DELIMITER):
-        """Return hierarhical name for a parameter."""
+        """Return hierarhical name for a parameter.
+
+        Returns a path of the form _brick1/brick2/brick3.parameter1_. The
+        delimiter is configurable.
+
+        Parameters
+        ----------
+        delimiter : str
+            The delimiter used to separate brick names in the path.
+
+        """
         return '{}.{}'.format(
             delimiter.join(
                 [""] + [brick.name for brick in

--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -15,7 +15,7 @@ from blocks.roles import add_role, PARAMETER, INPUT, OUTPUT
 from blocks.utils import dict_union, pack, repr_attrs, reraise_as, unpack
 from blocks.utils.containers import AnnotatingList
 
-BRICK_PATH_DELIMITER = '/'
+BRICK_DELIMITER = '/'
 
 
 def create_unbound_method(func, cls):
@@ -775,7 +775,7 @@ class Brick(Annotation):
         else:
             return [self]
 
-    def get_hierarchical_name(self, parameter, delimiter=BRICK_PATH_DELIMITER):
+    def get_hierarchical_name(self, parameter, delimiter=BRICK_DELIMITER):
         """Return hierarhical name for a parameter.
 
         Returns a path of the form _brick1/brick2/brick3.parameter1_. The

--- a/blocks/model.py
+++ b/blocks/model.py
@@ -20,7 +20,6 @@ from collections import OrderedDict, Counter
 from itertools import chain
 
 from blocks.graph import ComputationGraph
-from blocks.select import Selector
 from blocks.filter import get_brick
 
 logger = logging.getLogger(__name__)
@@ -75,14 +74,12 @@ class Model(ComputationGraph):
         if repeated_names:
             raise ValueError("top bricks with the same name:"
                              " {}".format(', '.join(repeated_names)))
-        brick_parameter_names = {
-            v: k for k, v in Selector(
-                self.top_bricks).get_parameters().items()}
         parameter_list = []
         for parameter in self.parameters:
-            if parameter in brick_parameter_names:
-                parameter_list.append((brick_parameter_names[parameter],
-                                       parameter))
+            if get_brick(parameter):
+                parameter_list.append(
+                    (get_brick(parameter).get_hierarchical_name(parameter),
+                     parameter))
             else:
                 parameter_list.append((parameter.name, parameter))
         self._parameter_dict = OrderedDict(parameter_list)

--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -136,12 +136,12 @@ except:
 from blocks.config import config
 from blocks.filter import get_brick
 from blocks.utils import change_recursion_limit
-from blocks.bricks.base import BRICK_PATH_DELIMITER
+from blocks.bricks.base import BRICK_DELIMITER
 
 
 logger = logging.getLogger(__name__)
 
-SERIALIZATION_BRICK_PATH_DELIMITER = '|'
+SERIALIZATION_BRICK_DELIMITER = '|'
 MAIN_MODULE_WARNING = """WARNING: Main loop depends on the function `{}` in \
 `__main__` namespace.
 
@@ -294,8 +294,8 @@ def load_parameters(file_):
 
     """
     with closing(_load_parameters_npzfile(file_)) as npz_file:
-        return {name.replace(SERIALIZATION_BRICK_PATH_DELIMITER,
-                             BRICK_PATH_DELIMITER): value
+        return {name.replace(SERIALIZATION_BRICK_DELIMITER,
+                             BRICK_DELIMITER): value
                 for name, value in npz_file.items()}
 
 
@@ -530,7 +530,7 @@ class _Renamer(object):
         # Standard Blocks parameter
         if get_brick(parameter) is not None:
             name = get_brick(parameter).get_hierarchical_name(
-                parameter, SERIALIZATION_BRICK_PATH_DELIMITER)
+                parameter, SERIALIZATION_BRICK_DELIMITER)
         # Shared variables with tag.name
         elif hasattr(parameter.tag, 'name'):
             name = parameter.tag.name

--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -136,11 +136,12 @@ except:
 from blocks.config import config
 from blocks.filter import get_brick
 from blocks.utils import change_recursion_limit
+from blocks.bricks.base import BRICK_PATH_DELIMITER
 
 
 logger = logging.getLogger(__name__)
 
-BRICK_DELIMITER = '|'
+SERIALIZATION_BRICK_PATH_DELIMITER = '|'
 MAIN_MODULE_WARNING = """WARNING: Main loop depends on the function `{}` in \
 `__main__` namespace.
 
@@ -293,7 +294,8 @@ def load_parameters(file_):
 
     """
     with closing(_load_parameters_npzfile(file_)) as npz_file:
-        return {name.replace(BRICK_DELIMITER, '/'): value
+        return {name.replace(SERIALIZATION_BRICK_PATH_DELIMITER,
+                             BRICK_PATH_DELIMITER): value
                 for name, value in npz_file.items()}
 
 
@@ -527,11 +529,8 @@ class _Renamer(object):
     def __call__(self, parameter):
         # Standard Blocks parameter
         if get_brick(parameter) is not None:
-            name = '{}.{}'.format(
-                BRICK_DELIMITER.join(
-                    [""] + [brick.name for brick in
-                            get_brick(parameter).get_unique_path()]),
-                parameter.name)
+            name = get_brick(parameter).get_hierarchical_name(
+                parameter, SERIALIZATION_BRICK_PATH_DELIMITER)
         # Shared variables with tag.name
         elif hasattr(parameter.tag, 'name'):
             name = parameter.tag.name


### PR DESCRIPTION
I have recently noticed that we save parameters using the names constructed by calling `Brick.unique_path` and load parameters (in `Model`) using parameters produced by `Selector`.  This weird discrepancy may cause bug in the case when a brick has multiple parents, whereby different names are used for loading and saving the same parameter.

This PR proposes to settle to a single method of naming parameters based on `get_unique_path`. I think makes sense to hardcode in the very core what is a name of a parameter. Also, `Selector` was never properly finished, and I don't think that the dependency of `Model` on `Selector` is a good thing.