### PR TITLE
Convolutions should default to tied_biases=True.

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -40,11 +40,11 @@ class Convolutional(LinearLike):
         The border mode to use, see :func:`scipy.signal.convolve2d` for
         details. Defaults to 'valid'.
     tied_biases : bool
-        If ``True``, it indicates that the biases of every filter in this
-        layer should be shared amongst all applications of that filter.
         Setting this to ``False`` will untie the biases, yielding a
         separate bias for every location at which the filter is applied.
-        Defaults to ``False``.
+        If ``True``, it indicates that the biases of every filter in this
+        layer should be shared amongst all applications of that filter.
+        Defaults to ``True``.
 
     """
     # Make it possible to override the implementation of conv2d that gets
@@ -71,7 +71,7 @@ class Convolutional(LinearLike):
     @lazy(allocation=['filter_size', 'num_filters', 'num_channels'])
     def __init__(self, filter_size, num_filters, num_channels, batch_size=None,
                  image_size=(None, None), step=(1, 1), border_mode='valid',
-                 tied_biases=False, **kwargs):
+                 tied_biases=True, **kwargs):
         super(Convolutional, self).__init__(**kwargs)
 
         self.filter_size = filter_size

--- a/tests/bricks/test_conv.py
+++ b/tests/bricks/test_conv.py
@@ -203,7 +203,7 @@ def test_untied_biases():
     filter_size = (3, 3)
     conv = Convolutional(filter_size, num_filters, num_channels,
                          weights_init=Constant(1.), biases_init=Constant(2.),
-                         image_size = (28, 30), tied_biases=False)
+                         image_size=(28, 30), tied_biases=False)
     conv.initialize()
 
     y = conv.apply(x)


### PR DESCRIPTION
Tied biases in convolutions brings bricks into alignment with other
libraries including Caffe, Lasange, and Keras, which tie biases
in convolutional layers by default.  Now tied_biases=False must be
specified explicitly to untie biases.