### PR TITLE
correction minor bug in search.py #1116

### DIFF
--- a/blocks/search.py
+++ b/blocks/search.py
@@ -110,7 +110,8 @@ class BeamSearch(object):
             applications=[self.generator.readout.emit], roles=[OUTPUT])(
                 self.inner_cg.variables)
         self.next_state_computer = function(
-            self.contexts + self.input_states + next_outputs, next_states)
+            self.contexts + self.input_states + next_outputs, next_states,
+            on_unused_input='ignore')
 
     def _compile_logprobs_computer(self):
         # This filtering should return identical variables


### PR DESCRIPTION
fix/fixes #1116
I corrected the bug just by adding, on_unused_input='ignore' , like in the functions [_compile_initial_state_and_context_computer](https://github.com/mila-udem/blocks/blob/master/blocks/search.py#L90) and [_compile_logprobs_computer](https://github.com/mila-udem/blocks/blob/master/blocks/search.py#L115):
```python
        self.next_state_computer = function(
            self.contexts + self.input_states + next_outputs, next_states, on_unused_input='ignore')
```