### PR TITLE
Provide exception to `on_error` extensions

### DIFF
--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -72,9 +72,15 @@ class TrainingExtension(object):
         pass
 
     @callback
-    def on_error(self):
-        """The callback invoked when an error occurs."""
-        pass
+    def on_error(self, exception):
+        """The callback invoked when an error occurs.
+
+        Parameters
+        ----------
+        exception : object
+            Exception occurred during the main loop run.
+
+        """
 
     @callback
     def before_training(self):

--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -189,7 +189,7 @@ class MainLoop(object):
                 self.log.current_row['got_exception'] = traceback.format_exc()
                 logger.error("Error occured during training." + error_message)
                 try:
-                    self._run_extensions('on_error')
+                    self._run_extensions('on_error', e)
                 except Exception:
                     logger.error(traceback.format_exc())
                     logger.error("Error occured when running extensions." +

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -5,7 +5,7 @@ from itertools import count
 from multiprocessing import Process
 
 from fuel.datasets import IterableDataset
-from mock import MagicMock
+from mock import MagicMock, ANY
 from numpy.testing import assert_raises
 from six.moves import cPickle
 
@@ -102,11 +102,11 @@ def test_error():
     ext.on_error = MagicMock()
     main_loop = MockMainLoop(extensions=[ext, FinishAfter(after_epoch=True)])
     assert_raises(KeyError, main_loop.run)
-    ext.on_error.assert_called_once_with()
+    ext.on_error.assert_called_once_with(ANY)
     assert 'got_exception' in main_loop.log.current_row
 
     ext.on_error = MagicMock(side_effect=AttributeError)
     main_loop = MockMainLoop(extensions=[ext, FinishAfter(after_epoch=True)])
     assert_raises(KeyError, main_loop.run)
-    ext.on_error.assert_called_once_with()
+    ext.on_error.assert_called_once_with(ANY)
     assert 'got_exception' in main_loop.log.current_row


### PR DESCRIPTION
It make a lot of sense to send an exception to the on_error extensions.

It makes possible to write this cool extension which is understands the traceback:
```python
class IPDB(SimpleExtension):
    """Runs ipdb debugger when an error occurs."""
    def __init__(self, **kwargs):
        kwargs.setdefault('on_error', True)
        super(IPDB, self).__init__(**kwargs)

    def do(self, which_callback, *args):
        if which_callback == 'on_error':
            exception, = args
            import ipdb
            ipdb.post_mortem(exception.__stacktrace__)
```

Simple postmortem debug is not able to navigate the stack trace.