### PR TITLE
fix inconsistent decay of beta1 in Adam

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -877,10 +877,10 @@ class Adam(StepRule):
         add_role(time, ALGORITHM_BUFFER)
 
         t1 = time + 1
+        beta_1t = 1. - (1. - self.beta1) * self.decay_factor ** (t1 - 1)
         learning_rate = (self.learning_rate *
                          tensor.sqrt((1. - (1. - self.beta2)**t1)) /
-                         (1. - (1. - self.beta1)**t1))
-        beta_1t = 1 - (1 - self.beta1) * self.decay_factor ** (t1 - 1)
+                         (1. - (1. - beta_1t)**t1))
         mean_t = beta_1t * previous_step + (1. - beta_1t) * mean
         variance_t = (self.beta2 * tensor.sqr(previous_step) +
                       (1. - self.beta2) * variance)


### PR DESCRIPTION
According to the Adam [paper](http://arxiv.org/pdf/1412.6980v8.pdf), the `beta1` that used to calculate stepsize should be the same with the one used to update biased first moment estimate. However, this bug won't cause a problem when `decay_factor` is very close to 1 or `t1` is small.
