### PR TITLE
Fix StepClipping return when threshold=None.

### DIFF
--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -696,12 +696,13 @@ class StepClipping(StepRule):
 
     """
     def __init__(self, threshold=None):
-        if threshold:
-            self.threshold = shared_floatx(threshold, "threshold")
-            add_role(self.threshold, ALGORITHM_HYPERPARAMETER)
+        if threshold is not None:
+            threshold = shared_floatx(threshold, "threshold")
+            add_role(threshold, ALGORITHM_HYPERPARAMETER)
+        self.threshold = threshold
 
     def compute_steps(self, previous_steps):
-        if not hasattr(self, 'threshold'):
+        if self.threshold is None:
             steps = previous_steps
         else:
             norm = l2_norm(previous_steps.values())

--- a/blocks/algorithms/__init__.py
+++ b/blocks/algorithms/__init__.py
@@ -702,13 +702,14 @@ class StepClipping(StepRule):
 
     def compute_steps(self, previous_steps):
         if not hasattr(self, 'threshold'):
-            return previous_steps
-        norm = l2_norm(previous_steps.values())
-        multiplier = tensor.switch(norm < self.threshold,
-                                   1, self.threshold / norm)
-        steps = OrderedDict(
-            (parameter, step * multiplier)
-            for parameter, step in previous_steps.items())
+            steps = previous_steps
+        else:
+            norm = l2_norm(previous_steps.values())
+            multiplier = tensor.switch(norm < self.threshold,
+                                       1, self.threshold / norm)
+            steps = OrderedDict(
+                (parameter, step * multiplier)
+                for parameter, step in previous_steps.items())
         return steps, []
 
 

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -311,6 +311,15 @@ def test_step_clipping():
     assert_allclose(clipped2[1].eval(), 4.0)
 
 
+def test_step_clipping_no_threshold_regression():
+    """Test regression for #1145, incorrect output when threshold=None."""
+    rule1 = StepClipping()
+    gradients = {0: shared_floatx(3.0), 1: shared_floatx(4.0)}
+    clipped1, updates = rule1.compute_steps(gradients)
+    assert len(updates) == 0
+    assert clipped1 == gradients
+
+
 def test_step_clipping_broadcastable():
     verify_broadcastable_handling(StepClipping(0.4))
 

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -314,6 +314,7 @@ def test_step_clipping():
 def test_step_clipping_no_threshold_regression():
     """Test regression for #1145, incorrect output when threshold=None."""
     rule1 = StepClipping()
+    assert rule1.threshold is None
     gradients = {0: shared_floatx(3.0), 1: shared_floatx(4.0)}
     clipped1, updates = rule1.compute_steps(gradients)
     assert len(updates) == 0


### PR DESCRIPTION
Fixes #1145.

N.B. I also consider it supremely weird that the threshold attribute isn't assigned in the case that it is None. I can change that too if asked.