### PR TITLE
Fix "read_data" timing

### DIFF
--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -637,15 +637,16 @@ class Timing(SimpleExtension):
         elif which_callback == 'after_epoch':
             level = 'epoch'
             counter = 'epochs_done'
-        for action in ['train', 'read_data']:
-            self.previous_index[level] = self.current_index[level]
-            self.current_index[level] = self.main_loop.log.status[counter]
-            if self.current_index[level] == self.previous_index[level]:
-                logger.debug('Timing extension was called twice this %s, '
-                             'log was not updated.', level)
-                # Nothing to report for this level
-                continue
 
+        self.previous_index[level] = self.current_index[level]
+        self.current_index[level] = self.main_loop.log.status[counter]
+        if self.current_index[level] == self.previous_index[level]:
+            logger.debug('Timing extension was called twice this %s, '
+                         'log was not updated.', level)
+            # Nothing to report for this level
+            return
+
+        for action in ['train', 'read_data']:
             self.previous[level][action] = self.current[level][action]
             self.current[level][action] = profile['training', 'epoch', action]
 


### PR DESCRIPTION
I believe that the code that check that this isn't a duplicate call of `Timing` should be outside of `for action in ... ` loop. @dmitriy-serdyuk , do you agree? I think it was you who refactored this extension last.