### PR TITLE
Fix for Pool.out_shape breaking change in Theano.

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -336,8 +336,8 @@ class Pooling(Initializable, Feedforward):
             return self.input_dim
         if name == 'output':
             return tuple(Pool.out_shape(
-                self.input_dim, self.pooling_size, st=self.step,
-                ignore_border=self.ignore_border, padding=self.padding))
+                (None,) + self.input_dim, self.pooling_size, st=self.step,
+                ignore_border=self.ignore_border, padding=self.padding))[1:]
 
     @property
     def num_output_channels(self):


### PR DESCRIPTION
This is causing our tests to fail and is caused by a boneheaded new
assumption in Theano/Theano@a16e91f7933e20b1ae77c1d43f8278af9333f2ab
that breaks old behaviour that we relied upon (see Theano/Theano#5088).

I don't really want to wait around for Theano to get its shit together,
so this introduces a version that works before and after the offending
Theano commit. It's already caught by our tests, obviously, so no
need for a regression test.