### PR TITLE
Make the Sequence brick implement the Sequence ADT.

### DIFF
--- a/blocks/bricks/conv.py
+++ b/blocks/bricks/conv.py
@@ -494,7 +494,6 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
     def __init__(self, layers, num_channels, batch_size=None,
                  image_size=(None, None), border_mode=None, tied_biases=None,
                  **kwargs):
-        self.layers = [a if isinstance(a, Brick) else a.brick for a in layers]
         self.image_size = image_size
         self.num_channels = num_channels
         self.batch_size = batch_size
@@ -503,6 +502,10 @@ class ConvolutionalSequence(Sequence, Initializable, Feedforward):
 
         super(ConvolutionalSequence, self).__init__(
             application_methods=layers, **kwargs)
+
+    @property
+    def layers(self):
+        return tuple(a.brick for a in self.application_methods)
 
     def get_dim(self, name):
         if name == 'input_':

--- a/blocks/bricks/sequences.py
+++ b/blocks/bricks/sequences.py
@@ -59,10 +59,14 @@ class Sequence(Brick, MutableSequence):
         return self.application_methods[index]
 
     def __setitem__(self, index, new_application):
+        if isinstance(new_application, Brick):
+            new_application = new_application.apply
         del self[index]
         self.insert(index, new_application)
 
     def insert(self, index, new_application):
+        if isinstance(new_application, Brick):
+            new_application = new_application.apply
         if new_application.brick not in self.children:
             self.children.append(new_application.brick)
         self.application_methods.insert(index, new_application)

--- a/blocks/bricks/sequences.py
+++ b/blocks/bricks/sequences.py
@@ -49,13 +49,11 @@ class Sequence(Brick, MutableSequence):
     def __delitem__(self, index):
         application_method = self.application_methods[index]
         brick = application_method.brick
-        try:
-            del self.application_methods[index]
-        finally:
-            apps_with_brick = [a for a in self.application_methods
-                               if a.brick is brick]
-            if len(apps_with_brick) == 0:
-                self.children.remove(brick)
+        del self.application_methods[index]
+        apps_with_brick = [a for a in self.application_methods
+                           if a.brick is brick]
+        if len(apps_with_brick) == 0:
+            self.children.remove(brick)
 
     def __getitem__(self, index):
         return self.application_methods[index]

--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -587,6 +587,14 @@ def test_sequence_setitem():
     yield check, 4  # last
 
 
+def test_sequence_setitem_brick():
+    apps = [Linear(i, i - 1).apply for i in range(5, 0, -1)]
+    s = Sequence(apps)
+    b = Identity()
+    s[2] = b
+    assert s.application_methods[2] == b.apply
+
+
 def test_sequence_insert():
     apps = [Linear(i, i - 1).apply for i in range(5, 0, -1)]
     apps.append(apps[0])
@@ -599,6 +607,17 @@ def test_sequence_insert():
     s.insert(6, a)
     assert s.application_methods[6] == a
     assert s.children.count(a.brick) == 1
+
+
+def test_sequence_insert_brick():
+    apps = [Linear(i, i - 1).apply for i in range(5, 0, -1)]
+    apps.append(apps[0])
+    s = Sequence(apps)
+    b = Linear(6, 5)
+    s.insert(0, b)
+    assert s.application_methods[0] == b.apply
+    s.insert(3, b)
+    assert s.application_methods[3] == b.apply
 
 
 def test_sequence_len():


### PR DESCRIPTION
This makes it a lot easier to do surgery on Sequence bricks. Say, for example, you have some code that generates a sequence and you want to customize it by adding or replacing layers; manually managing the `.children` and `.application_methods` attributes is a huge pain.

Marginally related to #1160.