### PR TITLE
fix progressbar's iter_per_epoch

### DIFF
--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -524,10 +524,14 @@ class ProgressBar(TrainingExtension):
     def get_iter_per_epoch(self):
         """Try to infer the number of iterations per epoch."""
         iter_scheme = self.main_loop.data_stream.iteration_scheme
-        if hasattr(iter_scheme, 'num_batches'):
-            return iter_scheme.num_batches
+        if (hasattr(iter_scheme, 'indices') and
+                not hasattr(iter_scheme, 'batch_size')):
+            return len(iter_scheme.indices)
+        elif (hasattr(iter_scheme, 'indices') and
+              hasattr(iter_scheme, 'batch_size')):
+            return len(iter_scheme.indices) // iter_scheme.batch_size
         elif (hasattr(iter_scheme, 'num_examples') and
-                hasattr(iter_scheme, 'batch_size')):
+              hasattr(iter_scheme, 'batch_size')):
             return iter_scheme.num_examples // iter_scheme.batch_size
         return None
 

--- a/blocks/extensions/__init__.py
+++ b/blocks/extensions/__init__.py
@@ -526,12 +526,15 @@ class ProgressBar(TrainingExtension):
         iter_scheme = self.main_loop.data_stream.iteration_scheme
         if (hasattr(iter_scheme, 'indices') and
                 not hasattr(iter_scheme, 'batch_size')):
+            # schemes that extend IndexScheme
             return len(iter_scheme.indices)
         elif (hasattr(iter_scheme, 'indices') and
               hasattr(iter_scheme, 'batch_size')):
+            # schemes that extend BatchScheme
             return len(iter_scheme.indices) // iter_scheme.batch_size
         elif (hasattr(iter_scheme, 'num_examples') and
               hasattr(iter_scheme, 'batch_size')):
+            # ConstantScheme
             return iter_scheme.num_examples // iter_scheme.batch_size
         return None
 

--- a/tests/extensions/test_progressbar.py
+++ b/tests/extensions/test_progressbar.py
@@ -1,6 +1,10 @@
 import numpy
 import theano
 from fuel.datasets import IterableDataset
+from fuel.schemes import (ConstantScheme,
+                          SequentialExampleScheme,
+                          SequentialScheme)
+from fuel.streams import DataStream
 from theano import tensor
 
 from blocks.algorithms import GradientDescent, Scale
@@ -9,7 +13,7 @@ from blocks.main_loop import MainLoop
 from blocks.utils import shared_floatx
 
 
-def setup_mainloop(extension):
+def setup_mainloop(extension, iteration_scheme=None):
     """Set up a simple main loop for progress bar tests.
 
     Create a MainLoop, register the given extension, supply it with a
@@ -23,6 +27,7 @@ def setup_mainloop(extension):
     features = [numpy.array(f, dtype=theano.config.floatX)
                 for f in [[1, 2]] * 101]
     dataset = IterableDataset(dict(features=features))
+    data_stream = DataStream(dataset, iteration_scheme=iteration_scheme)
 
     W = shared_floatx([0, 0], name='W')
     x = tensor.vector('features')
@@ -33,7 +38,8 @@ def setup_mainloop(extension):
                                 step_rule=Scale(1e-3))
 
     main_loop = MainLoop(
-        model=None, data_stream=dataset.get_example_stream(),
+        model=None,
+        data_stream=data_stream,
         algorithm=algorithm,
         extensions=[
             FinishAfter(after_n_epochs=1),
@@ -47,6 +53,38 @@ def test_progressbar():
 
     # We are happy if it does not crash or raise any exceptions
     main_loop.run()
+
+
+def test_progressbar_iter_per_epoch_indices():
+    iter_per_epoch = 100
+    progress_bar = ProgressBar()
+    main_loop = setup_mainloop(
+        None, iteration_scheme=SequentialExampleScheme(iter_per_epoch))
+    progress_bar.main_loop = main_loop
+
+    assert progress_bar.get_iter_per_epoch() == iter_per_epoch
+
+
+def test_progressbar_iter_per_epoch_batch_indices():
+    num_examples = 1000
+    batch_size = 10
+    progress_bar = ProgressBar()
+    main_loop = setup_mainloop(
+        None, iteration_scheme=SequentialScheme(num_examples, batch_size))
+    progress_bar.main_loop = main_loop
+
+    assert progress_bar.get_iter_per_epoch() == num_examples // batch_size
+
+
+def test_progressbar_iter_per_epoch_batch_examples():
+    num_examples = 1000
+    batch_size = 10
+    progress_bar = ProgressBar()
+    main_loop = setup_mainloop(
+        None, iteration_scheme=ConstantScheme(batch_size, num_examples))
+    progress_bar.main_loop = main_loop
+
+    assert progress_bar.get_iter_per_epoch() == num_examples // batch_size
 
 
 def test_printing():


### PR DESCRIPTION
the `ProgressBar` extension's `get_iter_per_epoch` was out of date and failing to get the iterations for most of the iteration schemes

- updates the `get_iter_per_epoch` method to use `indices` for iteration schemes that have it
- adds tests for the `get_iter_per_epoch` method
- fixes a little bit of indenting (check line 528 in `__init__.py` to see if it conforms with your standards)