### PR TITLE
Inherit load from SimpleExtension for flexibility

### DIFF
--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -2,7 +2,7 @@
 import os.path
 import logging
 
-from blocks.extensions import SimpleExtension, TrainingExtension
+from blocks.extensions import SimpleExtension
 from blocks.utils import reraise_as
 from blocks.serialization import (secure_dump, load, dump_and_add_to_dump,
                                   load_parameters)

--- a/blocks/extensions/saveload.py
+++ b/blocks/extensions/saveload.py
@@ -105,7 +105,7 @@ class Checkpoint(SimpleExtension):
             logger.info("Checkpointing has finished")
 
 
-class Load(TrainingExtension):
+class Load(SimpleExtension):
     """Loads a saved checkpoint into the main loop.
 
     Makes a `LOADED_FROM` record in the log with the dump path.
@@ -136,6 +136,7 @@ class Load(TrainingExtension):
     """
     def __init__(self, path, load_iteration_state=False, load_log=False,
                  **kwargs):
+        kwargs.setdefault("before_training", True)
         super(Load, self).__init__(**kwargs)
         self.path = path
         self.load_iteration_state = load_iteration_state
@@ -152,7 +153,7 @@ class Load(TrainingExtension):
                     main_loop.iteration_state = \
                         loaded_main_loop.iteration_state
 
-    def before_training(self):
+    def do(self, *args, **kwargs):
         if not os.path.exists(self.path):
             logger.warning("No dump found")
             return

--- a/tests/extensions/test_saveload.py
+++ b/tests/extensions/test_saveload.py
@@ -84,7 +84,7 @@ class TestCheckpoint(unittest.TestCase):
         """Check behaviour when loading nonexisting main loop."""
         load = Load('mynonexisting.tar')
         load.main_loop = self.main_loop
-        load.before_training()
+        load.do()
 
     def test_loading_exception(self):
         """Check loading exception."""
@@ -92,7 +92,7 @@ class TestCheckpoint(unittest.TestCase):
             f.write('a'.encode('utf-8'))
         load = Load(f.name)
         load.main_loop = self.main_loop
-        self.assertRaises(tarfile.ReadError, load.before_training)
+        self.assertRaises(tarfile.ReadError, load.do)
 
     def test_checkpoint_exception(self):
         """Check checkpoint exception."""


### PR DESCRIPTION
Inheriting `Load` from `SimpleExtension` has an advantage that it can be enabled/disabled by calling `SimpleExtension.set_conditions()`. It should be a super easy PR to review.