### PR TITLE
fix the crash with 'iteration_state'

### DIFF
--- a/blocks/main_loop.py
+++ b/blocks/main_loop.py
@@ -101,6 +101,7 @@ class MainLoop(object):
             extensions = []
 
         self.data_stream = data_stream
+        self.epoch_iterator = None
         self.algorithm = algorithm
         self.log = log
         self.extensions = extensions

--- a/tests/test_main_loop.py
+++ b/tests/test_main_loop.py
@@ -30,6 +30,9 @@ def test_main_loop():
     main_loop = MainLoop(
         MockAlgorithm(), IterableDataset(range(10)).get_example_stream(),
         extensions=[WriteBatchExtension(), FinishAfter(after_n_epochs=2)])
+    # regression test to check that accessing 'iteration_state'
+    # before training does not lead to a crash
+    main_loop.iteration_state
     main_loop.run()
     assert_raises(AttributeError, getattr, main_loop, 'model')
 


### PR DESCRIPTION
This PR fixes the issue with `iteration_state`: one could not access it before training.