### PR TITLE
perplexity aggregation scheme

### DIFF
--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -163,8 +163,7 @@ def perplexity(log_likelihood, n_examples):
     """Perplexity for total log_likelihood of n_examples."""
     variable = tensor.exp(-log_likelihood / n_examples)
     variable.tag.aggregation_scheme = Perplexity(log_likelihood, n_examples)
-    # There is no good default name for the output variable,
-    # so we don't try set any.
+    variable.name = 'perplexity'
     return variable
 
 

--- a/blocks/monitoring/aggregation.py
+++ b/blocks/monitoring/aggregation.py
@@ -143,11 +143,28 @@ class Mean(AggregationScheme):
         return aggregator
 
 
+class Perplexity(Mean):
+
+    def get_aggregator(self):
+        aggregator = super(Perplexity, self).get_aggregator()
+        aggregator.readout_variable = tensor.exp(-aggregator.readout_variable)
+        return aggregator
+
+
 def mean(numerator, denominator=1.):
     """Mean of quantity (numerator) over a number (denominator) values."""
     variable = numerator / denominator
     variable.tag.aggregation_scheme = Mean(numerator, denominator)
     variable.name = numerator.name
+    return variable
+
+
+def perplexity(log_likelihood, n_examples):
+    """Perplexity for total log_likelihood of n_examples."""
+    variable = tensor.exp(-log_likelihood / n_examples)
+    variable.tag.aggregation_scheme = Perplexity(log_likelihood, n_examples)
+    # There is no good default name for the output variable,
+    # so we don't try set any.
     return variable
 
 


### PR DESCRIPTION
This PR does two nice things: (a) improves the test of the `Mean` aggregation scheme to check what actually happens when batch sizes are different (b) adds and tests a `Perplexity` scheme, which in fact was the original motivation for the aggregation schemes 2 years ago..

@dmitriy-serdyuk , can you please review this?