### PR TITLE
Catch any exception on old backend import

### DIFF
--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -127,7 +127,7 @@ from six.moves import cPickle
 import theano
 try:
     from theano.sandbox.cuda import cuda_ndarray
-except ImportError:
+except:
     cuda_ndarray = None
 try:
     import pygpu

--- a/blocks/serialization.py
+++ b/blocks/serialization.py
@@ -127,11 +127,11 @@ from six.moves import cPickle
 import theano
 try:
     from theano.sandbox.cuda import cuda_ndarray
-except:
+except Exception:
     cuda_ndarray = None
 try:
     import pygpu
-except:
+except Exception:
     pygpu = None
 from blocks.config import config
 from blocks.filter import get_brick


### PR DESCRIPTION
Theano 9.0 crashes when trying to import the old backend.