### PR TITLE
Filter by unbound application and call_id

### DIFF
--- a/blocks/bricks/base.py
+++ b/blocks/bricks/base.py
@@ -247,6 +247,7 @@ class Application(object):
     def apply(self, bound_application, *args, **kwargs):
         as_dict = kwargs.pop('as_dict', False)
         as_list = kwargs.pop('as_list', False)
+        call_id = kwargs.pop('call_id', None)
         if as_list and as_dict:
             raise ValueError
 
@@ -259,6 +260,7 @@ class Application(object):
 
         # Construct the ApplicationCall, used to store data in for this call
         call = ApplicationCall(bound_application)
+        call.metadata['call_id'] = call_id
         args = list(args)
         if 'application' in args_names:
             args.insert(args_names.index('application'), bound_application)

--- a/tests/test_variable_filter.py
+++ b/tests/test_variable_filter.py
@@ -16,8 +16,8 @@ def test_variable_filter():
     activation = Logistic(name='sigm')
 
     x = tensor.vector()
-    h1 = brick1.apply(x)
-    h2 = activation.apply(h1)
+    h1 = brick1.apply(x, call_id='brick1_call_id')
+    h2 = activation.apply(h1, call_id='act')
     h2.name = "h2act"
     y = brick2.apply(h2)
     cg = ComputationGraph(y)
@@ -67,14 +67,18 @@ def test_variable_filter():
     theano_name_filter_regex = VariableFilter(theano_name_regex='h2a.?t')
     assert [cg.variables[11]] == theano_name_filter_regex(cg.variables)
 
+    brick1_apply_variables = [cg.variables[1], cg.variables[8]]
     # Testing filtering by application
     appli_filter = VariableFilter(applications=[brick1.apply])
-    variables = [cg.variables[1], cg.variables[8]]
-    assert variables == appli_filter(cg.variables)
+    assert brick1_apply_variables == appli_filter(cg.variables)
 
-    # Testing filtering by application
-    appli_filter_list = VariableFilter(applications=[brick1.apply])
-    assert variables == appli_filter_list(cg.variables)
+    # Testing filtering by unbound application
+    unbound_appli_filter = VariableFilter(applications=[Linear.apply])
+    assert brick1_apply_variables == unbound_appli_filter(cg.variables)
+
+    # Testing filtering by call identifier
+    call_id_filter = VariableFilter(call_id='brick1_call_id')
+    assert brick1_apply_variables == call_id_filter(cg.variables)
 
     input1 = tensor.matrix('input1')
     input2 = tensor.matrix('input2')


### PR DESCRIPTION
This PR does two things:

1) It makes it possible to filter by an unbound application, e.g. `Linear.apply`
2) It introduces an optional keyword argument `call_id` that writes a call identifier to the `metadata` attribute of the `ApplicationCall` object. `VariableFilter` is modified to support filtering by this new attribute. The usecase that I have in mind is when an application method is called twice, e.g. an RNN is used to encode both the question the answer. It is useful in such cases to make a distinction between the variables created in the first and in the second call. 